### PR TITLE
Fix: Disable autocomplete on persona page fields

### DIFF
--- a/pages/persona.html
+++ b/pages/persona.html
@@ -50,46 +50,46 @@
                 <!-- Core Identity Tab -->
                 <div id="core-identity-tab" class="element-tab active">
                     <div class="form-section glass-panel">
-                        <div class="form-group"><label for="persona-name">Name</label><input type="text" id="persona-name" class="input-field" data-field-id="name" placeholder="Full name, including any official titles, honorifics, or designations."></div>
-                        <div class="form-group"><label for="persona-aliases">Aliases & Nicknames</label><input type="text" id="persona-aliases" class="input-field" data-field-id="aliases" placeholder="Other names they go by and the context for each."></div>
-                        <div class="form-group"><label for="persona-pronouns">Gender & Pronouns</label><input type="text" id="persona-pronouns" class="input-field" data-field-id="pronouns" placeholder="e.g., she/her, he/him, they/them"></div>
-                        <div class="form-group"><label for="persona-archetype">Archetype</label><input type="text" id="persona-archetype" class="input-field" data-field-id="archetype" placeholder="e.g., The Mentor, The Rebel, The Trickster"></div>
-                        <div class="form-group"><label for="persona-pitch">One-Line Pitch</label><input type="text" id="persona-pitch" class="input-field" data-field-id="pitch" placeholder="A single, compelling sentence capturing the character's essence."></div>
+                        <div class="form-group"><label for="persona-name">Name</label><input type="text" id="persona-name" class="input-field" data-field-id="name" placeholder="Full name, including any official titles, honorifics, or designations." autocomplete="off"></div>
+                        <div class="form-group"><label for="persona-aliases">Aliases & Nicknames</label><input type="text" id="persona-aliases" class="input-field" data-field-id="aliases" placeholder="Other names they go by and the context for each." autocomplete="off"></div>
+                        <div class="form-group"><label for="persona-pronouns">Gender & Pronouns</label><input type="text" id="persona-pronouns" class="input-field" data-field-id="pronouns" placeholder="e.g., she/her, he/him, they/them" autocomplete="off"></div>
+                        <div class="form-group"><label for="persona-archetype">Archetype</label><input type="text" id="persona-archetype" class="input-field" data-field-id="archetype" placeholder="e.g., The Mentor, The Rebel, The Trickster" autocomplete="off"></div>
+                        <div class="form-group"><label for="persona-pitch">One-Line Pitch</label><input type="text" id="persona-pitch" class="input-field" data-field-id="pitch" placeholder="A single, compelling sentence capturing the character's essence." autocomplete="off"></div>
                     </div>
                 </div>
 
                 <!-- Appearance & Mannerisms Tab -->
                 <div id="appearance-tab" class="element-tab">
                     <div class="form-section glass-panel">
-                        <div class="form-group"><label for="persona-description">Physical Description</label><textarea id="persona-description" class="input-field" data-field-id="description" placeholder="Build, height, weight, hair/eye color, posture, gait, common expressions."></textarea></div>
-                        <div class="form-group"><label for="persona-features">Distinguishing Features</label><textarea id="persona-features" class="input-field" data-field-id="features" placeholder="Scars, tattoos, birthmarks, prosthetics, and the stories behind them."></textarea></div>
-                        <div class="form-group"><label for="ethnic-traits">Ethnic & Cultural Traits</label><textarea id="ethnic-traits" class="input-field" data-field-id="ethnicity" placeholder="Physical features and adornments connected to a specific heritage or group."></textarea></div>
-                        <div class="form-group"><label for="fashion-style">Fashion & Style</label><textarea id="fashion-style" class="input-field" data-field-id="style" placeholder="How they dress and the impression it creates (e.g., utilitarian, expensive, cultural)."></textarea></div>
-                        <div class="form-group"><label for="signature-items">Signature Items</label><textarea id="signature-items" class="input-field" data-field-id="items" placeholder="Objects they are never seen without (e.g., jewelry, weapon, book)."></textarea></div>
-                        <div class="form-group"><label for="voice-patterns">Voice & Speech Patterns</label><textarea id="voice-patterns" class="input-field" data-field-id="voice" placeholder="Tone, pitch, cadence, accent, vocabulary, slang."></textarea></div>
-                        <div class="form-group"><label for="personality-traits">Personality Traits</label><textarea id="personality-traits" class="input-field" data-field-id="personality" placeholder="Core disposition (e.g., cynical, optimistic). Can use frameworks like Myers-Briggs."></textarea></div>
-                        <div class="form-group"><label for="quirks-habits">Quirks & Habits</label><textarea id="quirks-habits" class="input-field" data-field-id="quirks" placeholder="Repeated behaviors that reveal personality (e.g., nervous tics, routines)."></textarea></div>
-                        <div class="form-group"><label for="personality-coding">Personality Coding</label><textarea id="personality-coding" class="input-field" data-field-id="coding" placeholder="Underlying psychological drivers (e.g., Enneagram type, core emotional state)."></textarea></div>
+                        <div class="form-group"><label for="persona-description">Physical Description</label><textarea id="persona-description" class="input-field" data-field-id="description" placeholder="Build, height, weight, hair/eye color, posture, gait, common expressions." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="persona-features">Distinguishing Features</label><textarea id="persona-features" class="input-field" data-field-id="features" placeholder="Scars, tattoos, birthmarks, prosthetics, and the stories behind them." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="ethnic-traits">Ethnic & Cultural Traits</label><textarea id="ethnic-traits" class="input-field" data-field-id="ethnicity" placeholder="Physical features and adornments connected to a specific heritage or group." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="fashion-style">Fashion & Style</label><textarea id="fashion-style" class="input-field" data-field-id="style" placeholder="How they dress and the impression it creates (e.g., utilitarian, expensive, cultural)." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="signature-items">Signature Items</label><textarea id="signature-items" class="input-field" data-field-id="items" placeholder="Objects they are never seen without (e.g., jewelry, weapon, book)." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="voice-patterns">Voice & Speech Patterns</label><textarea id="voice-patterns" class="input-field" data-field-id="voice" placeholder="Tone, pitch, cadence, accent, vocabulary, slang." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="personality-traits">Personality Traits</label><textarea id="personality-traits" class="input-field" data-field-id="personality" placeholder="Core disposition (e.g., cynical, optimistic). Can use frameworks like Myers-Briggs." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="quirks-habits">Quirks & Habits</label><textarea id="quirks-habits" class="input-field" data-field-id="quirks" placeholder="Repeated behaviors that reveal personality (e.g., nervous tics, routines)." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="personality-coding">Personality Coding</label><textarea id="personality-coding" class="input-field" data-field-id="coding" placeholder="Underlying psychological drivers (e.g., Enneagram type, core emotional state)." autocomplete="off"></textarea></div>
                     </div>
                 </div>
 
                 <!-- Narrative Profile Tab -->
                 <div id="narrative-tab" class="element-tab">
                     <div class="form-section glass-panel">
-                        <div class="form-group"><label for="persona-goals">Goals & Motivations</label><textarea id="persona-goals" class="input-field" data-field-id="goals" placeholder="Their primary external (plot) and internal (emotional) goals, and the 'why' behind them."></textarea></div>
-                        <div class="form-group"><label for="strengths-skills">Strengths & Skills</label><textarea id="strengths-skills" class="input-field" data-field-id="strengths" placeholder="Innate talents, learned skills, and special powers."></textarea></div>
-                        <div class="form-group"><label for="flaws-fears">Flaws & Fears</label><textarea id="flaws-fears" class="input-field" data-field-id="flaws" placeholder="Character flaws (e.g., arrogance) and deep-seated fears/phobias."></textarea></div>
-                        <div class="form-group"><label for="persona-history">Background & History</label><textarea id="persona-history" class="input-field" data-field-id="history" placeholder="Summary of their life story and defining moments."></textarea></div>
-                        <div class="form-group"><label for="persona-role">Role in Story</label><input type="text" id="persona-role" class="input-field" data-field-id="role" placeholder="e.g., Protagonist, Antagonist, Foil, Love Interest, Mentor."></textarea></div>
-                        <div class="form-group"><label for="persona-relationships">Relationships</label><textarea id="persona-relationships" class="input-field" data-field-id="relationships" placeholder="Map of key connections with allies, enemies, family, etc."></textarea></div>
-                        <div class="form-group"><label for="secrets">Secrets</label><textarea id="secrets" class="input-field" data-field-id="secrets" placeholder="What information do they hide and what are the consequences of its reveal?"></textarea></div>
+                        <div class="form-group"><label for="persona-goals">Goals & Motivations</label><textarea id="persona-goals" class="input-field" data-field-id="goals" placeholder="Their primary external (plot) and internal (emotional) goals, and the 'why' behind them." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="strengths-skills">Strengths & Skills</label><textarea id="strengths-skills" class="input-field" data-field-id="strengths" placeholder="Innate talents, learned skills, and special powers." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="flaws-fears">Flaws & Fears</label><textarea id="flaws-fears" class="input-field" data-field-id="flaws" placeholder="Character flaws (e.g., arrogance) and deep-seated fears/phobias." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="persona-history">Background & History</label><textarea id="persona-history" class="input-field" data-field-id="history" placeholder="Summary of their life story and defining moments." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="persona-role">Role in Story</label><input type="text" id="persona-role" class="input-field" data-field-id="role" placeholder="e.g., Protagonist, Antagonist, Foil, Love Interest, Mentor." autocomplete="off"></div>
+                        <div class="form-group"><label for="persona-relationships">Relationships</label><textarea id="persona-relationships" class="input-field" data-field-id="relationships" placeholder="Map of key connections with allies, enemies, family, etc." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="secrets">Secrets</label><textarea id="secrets" class="input-field" data-field-id="secrets" placeholder="What information do they hide and what are the consequences of its reveal?" autocomplete="off"></textarea></div>
                     </div>
                 </div>
 
                 <div class="form-section glass-panel">
                     <h5 class="form-subheader">Custom Notes</h5>
                     <div class="form-group">
-                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, notes, or custom fields here."></textarea>
+                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, notes, or custom fields here." autocomplete="off"></textarea>
                     </div>
                 </div>
 


### PR DESCRIPTION
This change disables the browser's autocomplete functionality for all input and textarea fields on the persona maker page (`pages/persona.html`).

This was done by adding the `autocomplete="off"` attribute to all relevant form elements. This prevents modern browsers from auto-filling fields with previously stored user data, which was causing issues for the user.