### PR TITLE
Refactor(species): implement tabbed interface and add new fields

### DIFF
--- a/pages/species.html
+++ b/pages/species.html
@@ -40,36 +40,62 @@
                 <button id="clear-fields-button" class="clear-btn">Clear All Fields</button>
             </div>
         </div>
-         <div class="workspace-layout">
+        <div class="workspace-layout">
             <div class="main-column">
-                <div class="form-section glass-panel" style="padding: 1.5rem;">
-                    <h4 id="SPECIES">Species Traits</h4>
-                    <h5 class="form-subheader">Core Identity</h5>
-                    <div class="form-group"><label for="species-name">Species Name</label><input type="text" id="species-name" class="input-field" data-field-id="name" placeholder="The formal or common name of the species."></div>
-                    <div class="form-group"><label for="species-classification">Classification</label><input type="text" id="species-classification" class="input-field" data-field-id="classification" placeholder="e.g., 'Sentient Mammal,' 'Silicon-based Flora,' 'Avian Predator.'"></div>
+                <div class="element-nav glass-panel">
+                    <button class="element-nav-button active" data-tab="core-identity">Core Identity</button>
+                    <button class="element-nav-button" data-tab="biology">Biology & Physiology</button>
+                    <button class="element-nav-button" data-tab="behavior">Behavior & Ecology</button>
+                    <button class="element-nav-button" data-tab="culture">Culture & Relations</button>
+                </div>
 
-                    <h5 class="form-subheader">Biology & Physiology</h5>
-                    <div class="form-group"><label for="species-anatomy">Physical Anatomy & Appearance</label><textarea id="species-anatomy" class="input-field" data-field-id="anatomy" placeholder="Size, shape, coloration, key features, and general appearance."></textarea></div>
-                    <div class="form-group"><label for="species-biology">Biological Systems & Life Cycle</label><textarea id="species-biology" class="input-field" data-field-id="biology" placeholder="Internal systems, metabolism, reproduction, and lifespan."></textarea></div>
-                    <div class="form-group"><label for="species-senses">Sensory Capabilities</label><textarea id="species-senses" class="input-field" data-field-id="senses" placeholder="Unique senses like echolocation, thermal vision, or psionic awareness."></textarea></div>
-                    <div class="form-group"><label for="species-abilities">Abilities & Powers</label><textarea id="species-abilities" class="input-field" data-field-id="abilities" placeholder="Special traits, unique skills, or natural defenses."></textarea></div>
-                    <div class="form-group"><label for="species-communication">Communication Methods</label><textarea id="species-communication" class="input-field" data-field-id="communication" placeholder="How they communicate: spoken language, telepathy, pheromones, etc."></textarea></div>
-
-                    <h5 class="form-subheader">Behavior & Ecology</h5>
-                    <div class="form-group"><label for="species-behavior">Behavior & Social Structure</label><textarea id="species-behavior" class="input-field" data-field-id="behavior" placeholder="Social hierarchies, temperament, and communal habits."></textarea></div>
-                    <div class="form-group"><label for="species-diet">Diet & Trophic Level</label><textarea id="species-diet" class="input-field" data-field-id="diet" placeholder="What they eat and their position in the food chain."></textarea></div>
-                    <div class="form-group"><label for="species-habitat">Habitat & Planetary Origin</label><textarea id="species-habitat" class="input-field" data-field-id="habitat" placeholder="Native environment and home world."></textarea></div>
-                    <div class="form-group"><label for="species-evolution">Evolutionary History</label><textarea id="species-evolution" class="input-field" data-field-id="evolution" placeholder="Ancestral forms and key evolutionary milestones."></textarea></div>
-
-                    <h5 class="form-subheader">Culture & Relations</h5>
-                    <div class="form-group"><label for="species-culture">Cultural Traits & Technology Level</label><textarea id="species-culture" class="input-field" data-field-id="culture" placeholder="Art, rituals, societal norms, and technological sophistication."></textarea></div>
-                    <div class="form-group"><label for="species-role">Ecological Role</label><textarea id="species-role" class="input-field" data-field-id="role" placeholder="Their impact on the ecosystem (e.g., keystone species, apex predator)."></textarea></div>
-                    <div class="form-group"><label for="species-relations">Inter-species Relations</label><textarea id="species-relations" class="input-field" data-field-id="relations" placeholder="How they interact with other species (e.g., symbiotic, parasitic, hostile)."></textarea></div>
-                    <h5 class="form-subheader">Custom Notes</h5>
-                    <div class="form-group">
-                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, notes, or custom fields here."></textarea>
+                <!-- Core Identity Tab -->
+                <div id="core-identity-tab" class="element-tab active">
+                    <div class="form-section glass-panel">
+                        <div class="form-group"><label for="species-name">Species Name</label><input type="text" id="species-name" class="input-field" data-field-id="name" placeholder="The formal or common name of the species." autocomplete="off"></div>
+                        <div class="form-group"><label for="species-classification">Classification</label><input type="text" id="species-classification" class="input-field" data-field-id="classification" placeholder="e.g., 'Sentient Mammal,' 'Silicon-based Flora,' 'Avian Predator.'" autocomplete="off"></div>
+                        <div class="form-group"><label for="species-origin">Origin</label><input type="text" id="species-origin" class="input-field" data-field-id="origin" placeholder="The native star system, planet, or dimension." autocomplete="off"></div>
                     </div>
                 </div>
+
+                <!-- Biology & Physiology Tab -->
+                <div id="biology-tab" class="element-tab">
+                    <div class="form-section glass-panel">
+                        <div class="form-group"><label for="species-anatomy">Physical Anatomy & Appearance</label><textarea id="species-anatomy" class="input-field" data-field-id="anatomy" placeholder="Size, shape, coloration, key features, and general appearance." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="species-biology">Biological Systems & Life Cycle</label><textarea id="species-biology" class="input-field" data-field-id="biology" placeholder="Internal systems, metabolism, reproduction, and lifespan." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="species-senses">Sensory Capabilities</label><textarea id="species-senses" class="input-field" data-field-id="senses" placeholder="Unique senses like echolocation, thermal vision, or psionic awareness." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="species-abilities">Abilities & Powers</label><textarea id="species-abilities" class="input-field" data-field-id="abilities" placeholder="Special traits, unique skills, or natural defenses." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="species-communication">Communication Methods</label><textarea id="species-communication" class="input-field" data-field-id="communication" placeholder="How they communicate: spoken language, telepathy, pheromones, etc." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="species-vulnerabilities">Biological Vulnerabilities</label><textarea id="species-vulnerabilities" class="input-field" data-field-id="vulnerabilities" placeholder="Weaknesses, environmental intolerance, or specific susceptibilities." autocomplete="off"></textarea></div>
+                    </div>
+                </div>
+
+                <!-- Behavior & Ecology Tab -->
+                <div id="behavior-tab" class="element-tab">
+                    <div class="form-section glass-panel">
+                        <div class="form-group"><label for="species-behavior">Behavior & Social Structure</label><textarea id="species-behavior" class="input-field" data-field-id="behavior" placeholder="Social hierarchies, temperament, and communal habits." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="species-diet">Diet & Trophic Level</label><textarea id="species-diet" class="input-field" data-field-id="diet" placeholder="What they eat and their position in the food chain." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="species-habitat">Habitat & Planetary Origin</label><textarea id="species-habitat" class="input-field" data-field-id="habitat" placeholder="Native environment and home world." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="species-evolution">Evolutionary History</label><textarea id="species-evolution" class="input-field" data-field-id="evolution" placeholder="Ancestral forms and key evolutionary milestones." autocomplete="off"></textarea></div>
+                    </div>
+                </div>
+
+                <!-- Culture & Relations Tab -->
+                <div id="culture-tab" class="element-tab">
+                    <div class="form-section glass-panel">
+                        <div class="form-group"><label for="species-culture">Cultural Traits & Technology Level</label><textarea id="species-culture" class="input-field" data-field-id="culture" placeholder="Art, rituals, societal norms, and technological sophistication." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="species-role">Ecological Role</label><textarea id="species-role" class="input-field" data-field-id="role" placeholder="Their impact on the ecosystem (e.g., keystone species, apex predator)." autocomplete="off"></textarea></div>
+                        <div class="form-group"><label for="species-relations">Inter-species Relations</label><textarea id="species-relations" class="input-field" data-field-id="relations" placeholder="How they interact with other species (e.g., symbiotic, parasitic, hostile)." autocomplete="off"></textarea></div>
+                    </div>
+                </div>
+
+                <div class="form-section glass-panel">
+                    <h5 class="form-subheader">Custom Notes</h5>
+                    <div class="form-group">
+                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, notes, or custom fields here." autocomplete="off"></textarea>
+                    </div>
+                </div>
+
                 <div id="response-container" class="response-container glass-panel"></div>
             </div>
             <div class="side-column">


### PR DESCRIPTION
This commit refactors the Species Creator page (`pages/species.html`) to improve usability and add new functionality.

Key changes include:
- Restructured the form into a tabbed interface, organizing fields into four categories: "Core Identity", "Biology & Physiology", "Behavior & Ecology", and "Culture & Relations". This mirrors the UI pattern used in the Persona Maker.
- Added a new "Origin" input field to the "Core Identity" section.
- Added a new "Biological Vulnerabilities" textarea to the "Biology & Physiology" section.
- Ensured all input fields and textareas have `autocomplete="off"` to prevent browser autofill.

The existing `initializeElementTabs` function in `script/element-bundle.js` is leveraged to power the new tab functionality without requiring any changes to the JavaScript.