### PR TITLE
feat: Add guidance gems for Philosophy element

### DIFF
--- a/script/element-bundle.js
+++ b/script/element-bundle.js
@@ -266,6 +266,12 @@ const allGemsData = {
         "Descriptive Style": ["Formal Technical Manual", "In-Universe Advertisement", "Scholarly Historical Entry", "Casual User Review"],
         "Perceived Reliability": ["Flawless & Dependable", "Reliable but Outdated", "Unstable & Dangerous", "Experimental & Unpredictable"],
         "User-Friendliness": ["Highly Intuitive", "Complex & Arcane", "Requires Special Training", "Physically Demanding"]
+    },
+    "PHILOSOPHY": {
+        "Organizational Structure": ["Strict Hierarchy", "Decentralized Cells", "Monastic Orders", "Charismatic Cult", "Academic Tradition"],
+        "Public Perception": ["Widely Accepted Mainstream", "Respected Ancient Tradition", "Fringe Belief System", "Outlawed Secret Society", "State Religion"],
+        "Dominant Tone": ["Dogmatic & Rigid", "Mystical & Esoteric", "Pragmatic & Secular", "Welcoming & Inclusive", "Ascetic & Disciplined"],
+        "Historical Influence": ["Ancient & Fading", "Currently Dominant Cultural Force", "New & Revolutionary Movement", "Subtle & Pervasive"]
     }
 };
 


### PR DESCRIPTION
Adds a new "PHILOSOPHY" key to the `allGemsData` object in `script/element-bundle.js`.

This introduces four new guidance categories and their corresponding options for the philosophy element page:
- Organizational Structure
- Public Perception
- Dominant Tone
- Historical Influence

This aligns the philosophy scribe element's guidance box with the user's requirements.