### PR TITLE
feat: Add Guidance Gems for Universe Element

### DIFF
--- a/script/element-bundle.js
+++ b/script/element-bundle.js
@@ -272,6 +272,14 @@ const allGemsData = {
         "Public Perception": ["Widely Accepted Mainstream", "Respected Ancient Tradition", "Fringe Belief System", "Outlawed Secret Society", "State Religion"],
         "Dominant Tone": ["Dogmatic & Rigid", "Mystical & Esoteric", "Pragmatic & Secular", "Welcoming & Inclusive", "Ascetic & Disciplined"],
         "Historical Influence": ["Ancient & Fading", "Currently Dominant Cultural Force", "New & Revolutionary Movement", "Subtle & Pervasive"]
+    },
+    "UNIVERSE": {
+        "Core Genre": ["Fantasy", "Science Fiction", "Horror", "Mystery", "Alternate History"],
+        "Genre Blends": ["Cyberpunk-Noir", "Steampunk-Fantasy", "Space Opera-Western", "Cosmic Horror-Mystery"],
+        "Dominant Tone": ["Grimdark", "Hopeful & Optimistic", "Satirical & Absurdist", "Whimsical & Lighthearted"],
+        "Cosmic Scope": ["Single Galaxy", "Multiverse", "Contained Pocket Dimension", "Planetary System"],
+        "Magic/Power System": ["Hard Magic (Rules-based)", "Soft Magic (Mysterious)", "Psionics", "No Supernatural Powers"],
+        "Technological Era": ["Ancient", "Medieval", "Industrial", "Information Age", "Futuristic"]
     }
 };
 


### PR DESCRIPTION
This commit introduces a new set of 'Guidance Gems' specifically for the 'UNIVERSE' element type, making them available on the Universe Crucible page.

The new guidance data is added to the `allGemsData` object in `script/element-bundle.js`, ensuring it is loaded dynamically based on the `data-element-type` attribute on the page's generate button.

A Playwright verification script was used to confirm that the new gems are correctly displayed in the user interface, and a screenshot of the successful verification is included in the development artifacts.