### PR TITLE
feat: Add responsive mobile menu for element pages

### DIFF
--- a/pages/persona.html
+++ b/pages/persona.html
@@ -34,6 +34,9 @@
     <main class="container">
         <div class="element-header">
             <h2 class="element-title animated-gradient">Persona Maker</h2>
+            <button id="mobile-menu-toggle" class="mobile-menu-toggle-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+            </button>
             <div class="header-actions">
                 <p class="element-subtitle">Craft the detailed identity of a character.</p>
             </div>

--- a/pages/philosophy.html
+++ b/pages/philosophy.html
@@ -35,6 +35,9 @@
         <!-- ... rest of philosophy.html content ... -->
         <div class="element-header">
             <h2 class="element-title animated-gradient">Philosophy Scribe</h2>
+            <button id="mobile-menu-toggle" class="mobile-menu-toggle-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+            </button>
             <div class="header-actions">
                 <p class="element-subtitle">Define a religion, belief system, or societal creed.</p>
             </div>

--- a/pages/scene.html
+++ b/pages/scene.html
@@ -35,6 +35,9 @@
         <!-- ... rest of scene.html content ... -->
         <div class="element-header">
             <h2 class="element-title animated-gradient">Scene Builder</h2>
+            <button id="mobile-menu-toggle" class="mobile-menu-toggle-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+            </button>
             <div class="header-actions">
                 <p class="element-subtitle">Construct the narrative beats of a single scene.</p>
             </div>

--- a/pages/setting.html
+++ b/pages/setting.html
@@ -35,6 +35,9 @@
         <!-- ... rest of setting.html content ... -->
         <div class="element-header">
             <h2 class="element-title animated-gradient">Setting Architect</h2>
+            <button id="mobile-menu-toggle" class="mobile-menu-toggle-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+            </button>
             <div class="header-actions">
                 <p class="element-subtitle">Design a specific location within your world.</p>
             </div>

--- a/pages/species.html
+++ b/pages/species.html
@@ -35,6 +35,9 @@
         <!-- ... rest of species.html content ... -->
         <div class="element-header">
             <h2 class="element-title animated-gradient">Species Creator</h2>
+            <button id="mobile-menu-toggle" class="mobile-menu-toggle-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+            </button>
             <div class="header-actions">
                 <p class="element-subtitle">Design the biology and culture of a new species.</p>
             </div>

--- a/pages/technology.html
+++ b/pages/technology.html
@@ -35,6 +35,9 @@
         <!-- ... rest of technology.html content ... -->
         <div class="element-header">
             <h2 class="element-title animated-gradient">Technology Forge</h2>
+            <button id="mobile-menu-toggle" class="mobile-menu-toggle-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+            </button>
             <div class="header-actions">
                 <p class="element-subtitle">Define a specific piece of technology and its impact.</p>
             </div>

--- a/pages/universe.html
+++ b/pages/universe.html
@@ -35,6 +35,9 @@
         <!-- ... rest of universe.html content ... -->
         <div class="element-header">
             <h2 class="element-title animated-gradient">Universe Crucible</h2>
+            <button id="mobile-menu-toggle" class="mobile-menu-toggle-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+            </button>
             <div class="header-actions">
                 <p class="element-subtitle">Establish the foundational framework of your story's universe.</p>
             </div>

--- a/pages/world.html
+++ b/pages/world.html
@@ -34,6 +34,9 @@
     <main class="container">
         <div class="element-header">
             <h2 class="element-title animated-gradient">World Anvil</h2>
+            <button id="mobile-menu-toggle" class="mobile-menu-toggle-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+            </button>
             <div class="header-actions">
                 <p class="element-subtitle">Forge the foundational laws and history of your universe.</p>
             </div>

--- a/script/element-bundle.js
+++ b/script/element-bundle.js
@@ -845,6 +845,35 @@ function initializeElementTabs() {
     });
 }
 
+// --- Mobile Menu ---
+function initializeMobileMenu() {
+    const toggleButton = document.getElementById('mobile-menu-toggle');
+    const sideColumn = document.querySelector('.side-column');
+    const mainColumn = document.querySelector('.main-column');
+
+    if (!toggleButton || !sideColumn || !mainColumn) return;
+
+    toggleButton.addEventListener('click', (e) => {
+        e.stopPropagation(); // Prevent the main column click listener from firing immediately
+        sideColumn.classList.toggle('is-open');
+    });
+
+    // Close the menu if clicking on the main content area
+    mainColumn.addEventListener('click', () => {
+        if (sideColumn.classList.contains('is-open')) {
+            sideColumn.classList.remove('is-open');
+        }
+    });
+
+    // Also close when a save/load/new button inside the menu is clicked
+    sideColumn.addEventListener('click', (e) => {
+        if (e.target.matches('.action-btn, .generate-btn-large, .save-btn-large, .import-btn')) {
+            sideColumn.classList.remove('is-open');
+        }
+    });
+}
+
+
 // --- DOMContentLoaded Initializer ---
 document.addEventListener('DOMContentLoaded', () => {
     // initializeResizableColumns(); // Intentionally disabled for stability
@@ -855,5 +884,6 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeSaveButton();
     initializeLoadButton();
     initializeNewButton();
-    initializeElementTabs(); // Add this line
+    initializeElementTabs();
+    initializeMobileMenu(); // Add this line
 });

--- a/style/style.css
+++ b/style/style.css
@@ -607,6 +607,82 @@ select.input-field {
     opacity: 0.5;
     cursor: not-allowed;
 }
+
+/* --- Mobile Responsive Styles --- */
+.mobile-menu-toggle-btn {
+    display: none; /* Hidden by default on large screens */
+    background: none;
+    border: 1px solid var(--panel-border);
+    color: var(--medium-text);
+    padding: 8px;
+    border-radius: 8px;
+    cursor: pointer;
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    z-index: 999;
+}
+
+.mobile-menu-toggle-btn:hover {
+    background-color: rgba(139, 148, 158, 0.1);
+    color: var(--light-text);
+}
+
+@media (max-width: 1024px) {
+    .workspace-layout {
+        flex-direction: column;
+    }
+
+    .side-column {
+        display: none; /* Hide side column by default on mobile */
+        width: 100%;   /* Take full width when open */
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--dark-bg);
+        z-index: 998;
+        overflow-y: auto;
+        padding: 1.5rem;
+        border-left: 1px solid var(--panel-border);
+    }
+
+    .side-column.is-open {
+        display: block; /* Show the side column when toggled */
+    }
+
+    .main-column {
+        width: 100%;
+    }
+
+    .mobile-menu-toggle-btn {
+        display: block; /* Show the hamburger button on mobile */
+    }
+
+    .element-header {
+        position: relative;
+        padding-right: 60px; /* Make space for the button */
+    }
+}
+
+@media (max-width: 768px) {
+    .container {
+        padding: 1.5rem 1rem;
+    }
+
+    .element-header {
+        padding-right: 50px;
+        text-align: left;
+    }
+
+    .element-title {
+        font-size: 2rem;
+    }
+
+    .header-actions {
+        justify-content: flex-start;
+    }
+}
 .generation-controls-buttons {
     display: grid;
     grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
This commit introduces a responsive design for the element pages that use a two-column layout.

On screens narrower than 1024px, the right-hand side column is now collapsed into a toggleable menu. A hamburger-style button is displayed in the header to control the visibility of this menu, improving the user experience on mobile devices.

Changes include:
- Added a mobile menu button to all relevant element pages.
- Updated `style/style.css` with media queries to handle the responsive layout and the new menu's styling.
- Implemented JavaScript in `script/element-bundle.js` to manage the menu's open/close state.