### PR TITLE
feat: Implement global sticky header and mobile menu

### DIFF
--- a/script/element-bundle.js
+++ b/script/element-bundle.js
@@ -845,44 +845,6 @@ function initializeElementTabs() {
     });
 }
 
-// --- Mobile Menu (Refactored) ---
-function initializeMobileMenu() {
-    const elementHeader = document.querySelector('.element-header');
-    const sideColumn = document.querySelector('.side-column');
-    const mainColumn = document.querySelector('.main-column');
-
-    // Only proceed if the necessary layout elements are present
-    if (!elementHeader || !sideColumn || !mainColumn) return;
-
-    // 1. Create the button dynamically
-    const toggleButton = document.createElement('button');
-    toggleButton.id = 'mobile-menu-toggle';
-    toggleButton.className = 'mobile-menu-toggle-btn';
-    toggleButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>`;
-
-    // 2. Inject the button into the header
-    elementHeader.appendChild(toggleButton);
-
-    // 3. Attach event listeners
-    toggleButton.addEventListener('click', (e) => {
-        e.stopPropagation();
-        sideColumn.classList.toggle('is-open');
-    });
-
-    mainColumn.addEventListener('click', () => {
-        if (sideColumn.classList.contains('is-open')) {
-            sideColumn.classList.remove('is-open');
-        }
-    });
-
-    sideColumn.addEventListener('click', (e) => {
-        if (e.target.matches('.action-btn, .generate-btn-large, .save-btn-large, .import-btn')) {
-            sideColumn.classList.remove('is-open');
-        }
-    });
-}
-
-
 // --- DOMContentLoaded Initializer ---
 document.addEventListener('DOMContentLoaded', () => {
     // initializeResizableColumns(); // Intentionally disabled for stability
@@ -894,5 +856,4 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeLoadButton();
     initializeNewButton();
     initializeElementTabs();
-    initializeMobileMenu(); // Add this line
 });

--- a/script/global-ui.js
+++ b/script/global-ui.js
@@ -299,11 +299,53 @@ function initializeAimeChatbot() {
 }
 
 
+// --- Global Mobile Menu ---
+function initializeGlobalMobileMenu() {
+    const headerLeft = document.querySelector('.main-header .header-left');
+    const sideColumn = document.querySelector('.side-column');
+    const mainColumn = document.querySelector('.main-column');
+
+    // Only run on pages that have the workspace layout
+    if (!headerLeft || !sideColumn || !mainColumn) return;
+
+    // 1. Create the button
+    const toggleButton = document.createElement('button');
+    toggleButton.id = 'mobile-menu-toggle';
+    toggleButton.className = 'mobile-menu-toggle-btn';
+    // Use a standard hamburger icon SVG
+    toggleButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>`;
+
+    // 2. Inject the button as the first item in the header's left container
+    headerLeft.insertBefore(toggleButton, headerLeft.firstChild);
+
+    // 3. Event Listeners
+    toggleButton.addEventListener('click', (e) => {
+        e.stopPropagation(); // Prevent click from bubbling to other elements
+        sideColumn.classList.toggle('is-open');
+    });
+
+    // Close menu if clicking on the main content area
+    mainColumn.addEventListener('click', () => {
+        if (sideColumn.classList.contains('is-open')) {
+            sideColumn.classList.remove('is-open');
+        }
+    });
+
+    // Close menu if a major action button is clicked within the side column for better UX
+    sideColumn.addEventListener('click', (e) => {
+        if (e.target.matches('.action-btn, .generate-btn-large, .save-btn-large, .import-btn, .gem-category-button')) {
+            sideColumn.classList.remove('is-open');
+        }
+    });
+}
+
+
 // Initialize all global UI components when the page content is loaded.
 document.addEventListener('DOMContentLoaded', () => {
     initializeSettingsModal();
     checkApiKeyStatus();
     initializeAutoExpandingTextareas();
+    initializeGlobalMobileMenu(); // Add mobile menu initialization
 
     // Initialize Chatbot
     // createAimeButton();

--- a/style/style.css
+++ b/style/style.css
@@ -58,6 +58,10 @@ body {
     align-items: center;
     padding: 1rem 1.5rem;
     border-bottom: 1px solid var(--panel-border);
+    position: sticky;
+    top: 0;
+    background-color: var(--dark-bg); /* Ensure it has a solid background when scrolling */
+    z-index: 900; /* Ensure it stays above most content */
 }
 
 .header-left {
@@ -610,17 +614,14 @@ select.input-field {
 
 /* --- Mobile Responsive Styles --- */
 .mobile-menu-toggle-btn {
-    display: none; /* Hidden by default on large screens */
+    display: none; /* Hidden by default, shown via media query */
     background: none;
     border: 1px solid var(--panel-border);
     color: var(--medium-text);
     padding: 8px;
     border-radius: 8px;
     cursor: pointer;
-    position: absolute;
-    top: 1.5rem;
-    right: 1.5rem;
-    z-index: 999;
+    z-index: 999; /* Ensure it's clickable */
 }
 
 .mobile-menu-toggle-btn:hover {
@@ -633,23 +634,24 @@ select.input-field {
         flex-direction: column;
     }
 
+    /* Redefine .side-column for mobile overlay behavior */
     .side-column {
-        display: none; /* Hide side column by default on mobile */
-        width: 100%;   /* Take full width when open */
-        position: fixed; /* Use fixed positioning to cover the whole screen */
+        display: none; /* Hidden by default */
+        position: fixed;
         top: 0;
-        right: 0;
-        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
         background-color: var(--dark-bg);
         z-index: 998;
         overflow-y: auto;
         padding: 1.5rem;
-        border-left: 1px solid var(--panel-border);
-        box-sizing: border-box; /* Ensure padding is included in the width */
+        box-sizing: border-box;
+        border: none; /* Remove border for full-screen overlay */
     }
 
     .side-column.is-open {
-        display: block; /* Show the side column when toggled */
+        display: block; /* Show when active */
     }
 
     .main-column {
@@ -657,12 +659,17 @@ select.input-field {
     }
 
     .mobile-menu-toggle-btn {
-        display: block; /* Show the hamburger button on mobile */
+        display: block; /* Show the toggle button */
     }
 
+    /* Hide the main navigation links and show the toggle button */
+    .main-nav {
+        display: none;
+    }
+
+    /* This rule is no longer needed as the button is in the header flow */
     .element-header {
-        position: relative;
-        padding-right: 60px; /* Make space for the button */
+        padding-right: 0;
     }
 }
 


### PR DESCRIPTION
This commit introduces a responsive, sticky header and a global mobile menu system that applies to all pages with a workspace layout.

Key changes include:
- Made the `.main-header` sticky using CSS (`position: sticky`) so it remains visible at the top of the viewport on scroll.
- Refactored the mobile menu logic from `element-bundle.js` into a new, global function `initializeGlobalMobileMenu` in `global-ui.js`.
- The new function dynamically injects a toggle button into the header on pages with a `.workspace-layout`.
- On screens narrower than 1024px, the main navigation is hidden, and the side column collapses into a full-screen overlay menu, toggleable by the new button.
- Cleaned up redundant code from `element-bundle.js`.

This ensures a consistent user experience across the application and improves code maintainability by centralizing the mobile navigation logic.