### PR TITLE
fix: Use direct frontend calls to Google AI API

### DIFF
--- a/script/writer-bundle.js
+++ b/script/writer-bundle.js
@@ -444,21 +444,16 @@ function initializeTabs() {
 
 async function generateContent(prompt) {
     const userApiKey = localStorage.getItem('AIME_API_KEY');
-    const model = 'gemini-1.5-flash-latest'; // UPDATED to cost-effective model
-    const apiUrl = `/api/proxy`; // UPDATED to use the backend proxy
+    const model = 'gemini-1.5-flash-latest';
 
-    // The backend proxy will handle the ultimate key logic,
-    // but we can check here for immediate user feedback.
     if (!userApiKey) {
-        // Using alert for simplicity, but a custom modal is better UX.
-        const proceed = confirm("API key not found in settings. The application will attempt to use a server-configured key if available. Do you want to continue?");
-        if (!proceed) {
-            return "Error: Generation cancelled by user.";
-        }
+        alert("API key not found. Please set it in the settings modal (the gear icon).");
+        return "Error: API key not found.";
     }
 
+    const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${userApiKey}`;
+
     const payload = {
-        model: model, // Send the desired model to the proxy
         contents: [{
             parts: [{
                 text: prompt
@@ -471,7 +466,6 @@ async function generateContent(prompt) {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'X-AIME-API-Key': userApiKey || '' // Send user's key to backend
             },
             body: JSON.stringify(payload)
         });

--- a/tests/usability/story_weaver_test.py
+++ b/tests/usability/story_weaver_test.py
@@ -105,6 +105,9 @@ def test_full_ai_workflow_e2e(page: Page):
     """
     page.goto(BASE_URL)
 
+    # Set a dummy API key in local storage to simulate a user-provided key
+    page.evaluate("() => localStorage.setItem('AIME_API_KEY', 'DUMMY_KEY')")
+
     # --- Mock API Responses ---
     mock_brainstorm_response = {
         "candidates": [{
@@ -158,13 +161,12 @@ def test_full_ai_workflow_e2e(page: Page):
     }
 
     # --- Setup Routes ---
-    page.route("**/api/proxy", lambda route: route.fulfill(status=200, json=mock_brainstorm_response))
-    page.on("dialog", lambda dialog: dialog.accept())
+    page.route("https://generativelanguage.googleapis.com/**", lambda route: route.fulfill(status=200, json=mock_brainstorm_response))
 
     # --- 1. Brainstorm ---
     page.locator("#main-prompt").fill("A lost city of crystals")
 
-    with page.expect_response("**/api/proxy"):
+    with page.expect_response("https://generativelanguage.googleapis.com/**"):
         page.locator("#generate-button").click()
 
     # Verify brainstorm cards are rendered
@@ -175,11 +177,11 @@ def test_full_ai_workflow_e2e(page: Page):
 
     # --- 2. Outline ---
     # Update route for the next API call
-    page.unroute("**/api/proxy")
-    page.route("**/api/proxy", lambda route: route.fulfill(status=200, json=mock_outline_response))
+    page.unroute("https://generativelanguage.googleapis.com/**")
+    page.route("https://generativelanguage.googleapis.com/**", lambda route: route.fulfill(status=200, json=mock_outline_response))
 
     # Click "Develop Outline" on the first card
-    with page.expect_response("**/api/proxy"):
+    with page.expect_response("https://generativelanguage.googleapis.com/**"):
         page.locator(".brainstorm-card", has_text="The Crystal City").locator(".develop-outline-btn").click()
 
     # Verify tab switch and outline rendering
@@ -191,11 +193,11 @@ def test_full_ai_workflow_e2e(page: Page):
 
     # --- 3. Draft ---
     # Update route for the final API call
-    page.unroute("**/api/proxy")
-    page.route("**/api/proxy", lambda route: route.fulfill(status=200, json=mock_draft_response))
+    page.unroute("https://generativelanguage.googleapis.com/**")
+    page.route("https://generativelanguage.googleapis.com/**", lambda route: route.fulfill(status=200, json=mock_draft_response))
 
     # Click "Create Treatment"
-    with page.expect_response("**/api/proxy"):
+    with page.expect_response("https://generativelanguage.googleapis.com/**"):
         page.locator("#create-treatment-from-outline-btn").click()
 
     # Verify tab switch and draft content


### PR DESCRIPTION
This commit refactors the Story Weaver's content generation logic to make direct API calls from the frontend to the Google AI service, instead of using a backend proxy. This aligns with the intended architecture and resolves the `JSON.parse` error that occurred when the proxy failed.

Changes:
- `script/writer-bundle.js`: The `generateContent` function now constructs the full Google AI API URL and uses the user's key from local storage.
- `tests/usability/story_weaver_test.py`: The e2e test has been updated to mock the external `https://generativelanguage.googleapis.com` endpoint.
- `server/app.py`: The unnecessary changes to the backend proxy have been reverted.