### PR TITLE
feat: Implement edit mode toggle for content canvases

### DIFF
--- a/jules-scratch/verification/verify_edit_toggle_final.py
+++ b/jules-scratch/verification/verify_edit_toggle_final.py
@@ -1,0 +1,82 @@
+from playwright.sync_api import sync_playwright, Page, expect
+import os
+
+def run_writer_verification(page: Page):
+    """
+    Verifies the edit toggle functionality on the writer page.
+    """
+    base_url = "http://127.0.0.1:5001"
+    writer_url = f"{base_url}/pages/writer.html"
+
+    # Navigate to the writer page
+    page.goto(writer_url)
+
+    # --- Test Brainstorm Tab ---
+    brainstorm_canvas = page.locator("#brainstorm-response-area")
+    brainstorm_toggle = page.locator('.edit-toggle[data-target="brainstorm-response-area"]')
+    expect(brainstorm_canvas).to_have_attribute("contenteditable", "false")
+    expect(brainstorm_toggle).not_to_be_checked()
+    brainstorm_toggle.click()
+    expect(brainstorm_canvas).to_have_attribute("contenteditable", "true")
+    expect(brainstorm_toggle).to_be_checked()
+
+    # --- Test Outline Tab ---
+    outline_tab_button = page.get_by_role("button", name="2. Outline")
+    outline_tab_button.click()
+    outline_canvas = page.locator("#outline-list")
+    outline_toggle = page.locator('.edit-toggle[data-target="outline-list"]')
+    expect(outline_canvas).to_have_attribute("contenteditable", "false")
+    expect(outline_toggle).not_to_be_checked()
+    outline_toggle.click()
+    expect(outline_canvas).to_have_attribute("contenteditable", "true")
+    expect(outline_toggle).to_be_checked()
+
+    # --- Test Draft Tab ---
+    draft_tab_button = page.get_by_role("button", name="3. Draft")
+    draft_tab_button.click()
+    treatment_canvas = page.locator("#treatment-canvas")
+    treatment_toggle = page.locator('.edit-toggle[data-target="treatment-canvas"]')
+    expect(treatment_canvas).to_have_attribute("contenteditable", "false")
+    expect(treatment_toggle).not_to_be_checked()
+    treatment_toggle.click()
+    expect(treatment_canvas).to_have_attribute("contenteditable", "true")
+    expect(treatment_toggle).to_be_checked()
+
+    page.screenshot(path="jules-scratch/verification/writer_page_verified.png")
+
+def run_element_verification(page: Page):
+    """
+    Verifies the edit toggle functionality on an element page (persona.html).
+    """
+    base_url = "http://127.0.0.1:5001"
+    persona_url = f"{base_url}/pages/persona.html"
+
+    # Navigate to the persona page
+    page.goto(persona_url)
+
+    # --- Test Notes Tab ---
+    notes_tab_button = page.get_by_role("button", name="Notes")
+    notes_tab_button.click()
+    notes_textarea = page.locator("#custom-notes")
+    notes_toggle = page.locator('.edit-toggle[data-target="custom-notes"]')
+    expect(notes_textarea).to_be_disabled()
+    expect(notes_toggle).not_to_be_checked()
+    notes_toggle.click()
+    expect(notes_textarea).to_be_enabled()
+    expect(notes_toggle).to_be_checked()
+    notes_textarea.type("Testing notes editability.")
+    expect(notes_textarea).to_have_value("Testing notes editability.")
+
+    page.screenshot(path="jules-scratch/verification/element_page_verified.png")
+
+
+def main():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        run_writer_verification(page)
+        run_element_verification(page)
+        browser.close()
+
+if __name__ == "__main__":
+    main()

--- a/pages/faction.html
+++ b/pages/faction.html
@@ -107,9 +107,18 @@
                 </div>
 
                 <div class="form-section glass-panel">
-                    <h5 class="form-subheader">Custom Notes</h5>
+                    <div class="tab-controls glass-panel" style="margin-bottom: 1rem; border-bottom: none; padding: 0;">
+                        <h5 class="form-subheader">Custom Notes</h5>
+                        <div class="edit-toggle-container">
+                            <span class="edit-toggle-label">Edit</span>
+                            <label class="edit-toggle-switch">
+                                <input type="checkbox" class="edit-toggle" data-target="custom-notes">
+                                <span class="edit-toggle-slider"></span>
+                            </label>
+                        </div>
+                    </div>
                     <div class="form-group">
-                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, notes, or custom fields here." autocomplete="off"></textarea>
+                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, ideas, dialogue snippets, or custom fields here." autocomplete="off" disabled></textarea>
                     </div>
                 </div>
 

--- a/pages/persona.html
+++ b/pages/persona.html
@@ -184,9 +184,18 @@
                 <!-- Notes Tab -->
                 <div id="notes-tab" class="element-tab">
                     <div class="form-section glass-panel">
-                        <h5 class="form-subheader">General Notes</h5>
+                        <div class="tab-controls glass-panel" style="margin-bottom: 1rem; border-bottom: none; padding: 0;">
+                            <h5 class="form-subheader">General Notes</h5>
+                            <div class="edit-toggle-container">
+                                <span class="edit-toggle-label">Edit</span>
+                                <label class="edit-toggle-switch">
+                                    <input type="checkbox" class="edit-toggle" data-target="custom-notes">
+                                    <span class="edit-toggle-slider"></span>
+                                </label>
+                            </div>
+                        </div>
                         <div class="form-group">
-                            <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, ideas, dialogue snippets, or custom fields here." autocomplete="off"></textarea>
+                            <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, ideas, dialogue snippets, or custom fields here." autocomplete="off" disabled></textarea>
                         </div>
                     </div>
                 </div>

--- a/pages/philosophy.html
+++ b/pages/philosophy.html
@@ -81,9 +81,18 @@
                 </div>
 
                 <div class="form-section glass-panel">
-                    <h5 class="form-subheader">Custom Notes</h5>
+                    <div class="tab-controls glass-panel" style="margin-bottom: 1rem; border-bottom: none; padding: 0;">
+                        <h5 class="form-subheader">Custom Notes</h5>
+                        <div class="edit-toggle-container">
+                            <span class="edit-toggle-label">Edit</span>
+                            <label class="edit-toggle-switch">
+                                <input type="checkbox" class="edit-toggle" data-target="custom-notes">
+                                <span class="edit-toggle-slider"></span>
+                            </label>
+                        </div>
+                    </div>
                     <div class="form-group">
-                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, notes, or custom fields here." autocomplete="off"></textarea>
+                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, ideas, dialogue snippets, or custom fields here." autocomplete="off" disabled></textarea>
                     </div>
                 </div>
 

--- a/pages/scene.html
+++ b/pages/scene.html
@@ -79,11 +79,20 @@
 
     <!-- Custom Notes (outside tabs) -->
     <div class="form-section glass-panel">
-                    <h5 class="form-subheader">Custom Notes</h5>
-                    <div class="form-group">
-                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, notes, or custom fields here."></textarea>
-                    </div>
-                </div>
+        <div class="tab-controls glass-panel" style="margin-bottom: 1rem; border-bottom: none; padding: 0;">
+            <h5 class="form-subheader">Custom Notes</h5>
+            <div class="edit-toggle-container">
+                <span class="edit-toggle-label">Edit</span>
+                <label class="edit-toggle-switch">
+                    <input type="checkbox" class="edit-toggle" data-target="custom-notes">
+                    <span class="edit-toggle-slider"></span>
+                </label>
+            </div>
+        </div>
+        <div class="form-group">
+            <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, ideas, dialogue snippets, or custom fields here." autocomplete="off" disabled></textarea>
+        </div>
+    </div>
 
                 <div id="response-container" class="response-container glass-panel"></div>
             </div>

--- a/pages/setting.html
+++ b/pages/setting.html
@@ -79,9 +79,18 @@
                 </div>
 
                 <div class="form-section glass-panel">
-                    <h5 class="form-subheader">Custom Notes</h5>
+                    <div class="tab-controls glass-panel" style="margin-bottom: 1rem; border-bottom: none; padding: 0;">
+                        <h5 class="form-subheader">Custom Notes</h5>
+                        <div class="edit-toggle-container">
+                            <span class="edit-toggle-label">Edit</span>
+                            <label class="edit-toggle-switch">
+                                <input type="checkbox" class="edit-toggle" data-target="custom-notes">
+                                <span class="edit-toggle-slider"></span>
+                            </label>
+                        </div>
+                    </div>
                     <div class="form-group">
-                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, notes, or custom fields here." autocomplete="off"></textarea>
+                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, ideas, dialogue snippets, or custom fields here." autocomplete="off" disabled></textarea>
                     </div>
                 </div>
 

--- a/pages/species.html
+++ b/pages/species.html
@@ -89,9 +89,18 @@
                 </div>
 
                 <div class="form-section glass-panel">
-                    <h5 class="form-subheader">Custom Notes</h5>
+                    <div class="tab-controls glass-panel" style="margin-bottom: 1rem; border-bottom: none; padding: 0;">
+                        <h5 class="form-subheader">Custom Notes</h5>
+                        <div class="edit-toggle-container">
+                            <span class="edit-toggle-label">Edit</span>
+                            <label class="edit-toggle-switch">
+                                <input type="checkbox" class="edit-toggle" data-target="custom-notes">
+                                <span class="edit-toggle-slider"></span>
+                            </label>
+                        </div>
+                    </div>
                     <div class="form-group">
-                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, notes, or custom fields here." autocomplete="off"></textarea>
+                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, ideas, dialogue snippets, or custom fields here." autocomplete="off" disabled></textarea>
                     </div>
                 </div>
 

--- a/pages/technology.html
+++ b/pages/technology.html
@@ -80,9 +80,18 @@
                 </div>
 
                 <div class="form-section glass-panel">
-                    <h5 class="form-subheader">Custom Notes</h5>
+                    <div class="tab-controls glass-panel" style="margin-bottom: 1rem; border-bottom: none; padding: 0;">
+                        <h5 class="form-subheader">Custom Notes</h5>
+                        <div class="edit-toggle-container">
+                            <span class="edit-toggle-label">Edit</span>
+                            <label class="edit-toggle-switch">
+                                <input type="checkbox" class="edit-toggle" data-target="custom-notes">
+                                <span class="edit-toggle-slider"></span>
+                            </label>
+                        </div>
+                    </div>
                     <div class="form-group">
-                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, notes, or custom fields here." autocomplete="off"></textarea>
+                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, ideas, dialogue snippets, or custom fields here." autocomplete="off" disabled></textarea>
                     </div>
                 </div>
                 <div id="response-container" class="response-container glass-panel"></div>

--- a/pages/universe.html
+++ b/pages/universe.html
@@ -82,9 +82,18 @@
                         <div class="form-group"><label for="cosmology-phenomena">Unique Celestial Phenomena</label><textarea id="cosmology-phenomena" class="input-field" data-field-id="cosmology_phenomena" placeholder="e.g., Living stars, crystalline asteroid fields, temporal rifts." autocomplete="off"></textarea></div>
                     </div>
 
-                    <h5 class="form-subheader">Custom Notes</h5>
+                    <div class="tab-controls glass-panel" style="margin-bottom: 1rem; border-bottom: none; padding: 0;">
+                        <h5 class="form-subheader">Custom Notes</h5>
+                        <div class="edit-toggle-container">
+                            <span class="edit-toggle-label">Edit</span>
+                            <label class="edit-toggle-switch">
+                                <input type="checkbox" class="edit-toggle" data-target="custom-notes">
+                                <span class="edit-toggle-slider"></span>
+                            </label>
+                        </div>
+                    </div>
                     <div class="form-group">
-                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, notes, or custom fields here." autocomplete="off"></textarea>
+                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, ideas, dialogue snippets, or custom fields here." autocomplete="off" disabled></textarea>
                     </div>
                 </div>
                 <div id="response-container" class="response-container glass-panel"></div>

--- a/pages/world.html
+++ b/pages/world.html
@@ -90,9 +90,18 @@
                 </div>
 
                 <div class="form-section glass-panel">
-                    <h5 class="form-subheader">Custom Notes</h5>
+                    <div class="tab-controls glass-panel" style="margin-bottom: 1rem; border-bottom: none; padding: 0;">
+                        <h5 class="form-subheader">Custom Notes</h5>
+                        <div class="edit-toggle-container">
+                            <span class="edit-toggle-label">Edit</span>
+                            <label class="edit-toggle-switch">
+                                <input type="checkbox" class="edit-toggle" data-target="custom-notes">
+                                <span class="edit-toggle-slider"></span>
+                            </label>
+                        </div>
+                    </div>
                     <div class="form-group">
-                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, notes, or custom fields here." autocomplete="off"></textarea>
+                        <textarea id="custom-notes" class="input-field" data-field-id="custom_notes" placeholder="Add any other relevant details, ideas, dialogue snippets, or custom fields here." autocomplete="off" disabled></textarea>
                     </div>
                 </div>
 

--- a/pages/writer.html
+++ b/pages/writer.html
@@ -43,6 +43,13 @@
                 <div id="brainstorm-tab" class="writer-tab active">
                     <div class="tab-controls glass-panel">
                         <h3 class="tab-title">Brainstorm Concepts</h3>
+                        <div class="edit-toggle-container">
+                            <span class="edit-toggle-label">Edit</span>
+                            <label class="edit-toggle-switch">
+                                <input type="checkbox" class="edit-toggle" data-target="brainstorm-response-area">
+                                <span class="edit-toggle-slider"></span>
+                            </label>
+                        </div>
                     </div>
                     <div id="brainstorm-response-area" class="response-area-cards">
                         <p class="placeholder-text">Enter a core idea in the prompt box and click "Brainstorm Concepts" to generate story ideas.</p>
@@ -52,6 +59,13 @@
                 <div id="outline-tab" class="writer-tab">
                     <div class="tab-controls glass-panel">
                         <h3 class="tab-title">Build Your Outline</h3>
+                        <div class="edit-toggle-container">
+                            <span class="edit-toggle-label">Edit</span>
+                            <label class="edit-toggle-switch">
+                                <input type="checkbox" class="edit-toggle" data-target="outline-list">
+                                <span class="edit-toggle-slider"></span>
+                            </label>
+                        </div>
                         <button id="create-treatment-from-outline-btn" class="action-btn">Create Treatment</button>
                     </div>
                     <ul id="outline-list" class="outline-list">
@@ -62,6 +76,13 @@
                 <div id="treatment-tab" class="writer-tab">
                     <div class="tab-controls glass-panel">
                         <h3 class="tab-title">Draft Your Story</h3>
+                        <div class="edit-toggle-container">
+                            <span class="edit-toggle-label">Edit</span>
+                            <label class="edit-toggle-switch">
+                                <input type="checkbox" class="edit-toggle" data-target="treatment-canvas">
+                                <span class="edit-toggle-slider"></span>
+                            </label>
+                        </div>
                     </div>
                     <div id="treatment-canvas" class="writing-canvas glass-panel" contenteditable="true">
                          <p class="placeholder-text">Generate an outline, then click "Generate Treatment" to create a story treatment here.</p>

--- a/script/element-bundle.js
+++ b/script/element-bundle.js
@@ -878,6 +878,36 @@ function initializeSubTabs() {
     });
 }
 
+// --- Edit Mode Toggles ---
+function initializeEditToggles() {
+    const toggles = document.querySelectorAll('.edit-toggle');
+    toggles.forEach(toggle => {
+        const targetId = toggle.dataset.target;
+        const targetElement = document.getElementById(targetId);
+
+        if (targetElement) {
+            // Add the editable-area class for styling
+            targetElement.classList.add('editable-area');
+
+            // Set initial state: The textarea should be disabled, and the toggle should be off.
+            targetElement.disabled = true;
+            toggle.checked = false;
+            targetElement.classList.remove('is-editable');
+
+            toggle.addEventListener('change', (e) => {
+                const isEditable = e.target.checked;
+                targetElement.disabled = !isEditable;
+                if (isEditable) {
+                    targetElement.classList.add('is-editable');
+                    targetElement.focus();
+                } else {
+                    targetElement.classList.remove('is-editable');
+                }
+            });
+        }
+    });
+}
+
 // --- DOMContentLoaded Initializer ---
 document.addEventListener('DOMContentLoaded', () => {
     initializeResizableColumns(); // Intentionally disabled for stability
@@ -890,6 +920,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeNewButton();
     initializeElementTabs();
     initializeSubTabs();
+    initializeEditToggles();
 });
 
 

--- a/script/writer-bundle.js
+++ b/script/writer-bundle.js
@@ -621,7 +621,7 @@ function initializeGeneration() {
                 break;
             case 'outline':
                 const outlineList = document.getElementById('outline-list');
-                const existingText = outlineList.innerText;
+                const existingText = outlineList.innerText; // Use innerText to get the current, potentially edited content
                 generatePlotPoint(existingText);
                 break;
             case 'treatment':
@@ -798,9 +798,9 @@ function initializeWorkflowButtons() {
             const card = e.target.closest('.brainstorm-card');
             if (!card) return;
 
-            const title = card.querySelector('.card-title').textContent;
-            const logline = card.querySelector('.brainstorm-logline').textContent;
-            const concept = card.querySelector('.brainstorm-concept').textContent;
+            const title = card.querySelector('.card-title').innerText;
+            const logline = card.querySelector('.brainstorm-logline').innerText;
+            const concept = card.querySelector('.brainstorm-concept').innerText;
             const fullConcept = `Title: ${title}\nLogline: ${logline}\nConcept: ${concept}`;
 
             const outlineTabButton = document.querySelector('.writer-nav-button[data-tab="outline"]');
@@ -849,8 +849,8 @@ async function generateTreatment() {
 
     let fullOutline = "Please write a detailed story treatment based on the following ordered plot points:\n\n";
     outlineItems.forEach((item, index) => {
-        const title = item.querySelector('.outline-item-title').textContent;
-        const description = item.querySelector('.outline-item-description').textContent;
+        const title = item.querySelector('.outline-item-title').innerText;
+        const description = item.querySelector('.outline-item-description').innerText;
         fullOutline += `${index + 1}. ${title}: ${description}\n`;
     });
 
@@ -1218,6 +1218,50 @@ function loadOutlineContent(content) {
     }
 }
 
+// --- Edit Mode Toggles ---
+function initializeEditToggles() {
+    const toggles = document.querySelectorAll('.edit-toggle');
+    toggles.forEach(toggle => {
+        const targetId = toggle.dataset.target;
+        const targetElement = document.getElementById(targetId);
+
+        if (targetElement) {
+            // Add the editable-area class for styling
+            targetElement.classList.add('editable-area');
+
+            // Set initial state
+            const isChecked = toggle.checked;
+            targetElement.contentEditable = isChecked;
+            if (isChecked) {
+                targetElement.classList.add('is-editable');
+            } else {
+                targetElement.classList.remove('is-editable');
+            }
+
+            const childEditables = targetElement.querySelectorAll('.editable-content');
+            childEditables.forEach(child => {
+                child.contentEditable = isChecked;
+            });
+
+            toggle.addEventListener('change', (e) => {
+                const isEditable = e.target.checked;
+                targetElement.contentEditable = isEditable;
+
+                if (isEditable) {
+                    targetElement.classList.add('is-editable');
+                } else {
+                    targetElement.classList.remove('is-editable');
+                }
+
+                const childEditables = targetElement.querySelectorAll('.editable-content');
+                childEditables.forEach(child => {
+                    child.contentEditable = isEditable;
+                });
+            });
+        }
+    });
+}
+
 // --- DOMContentLoaded Initializer ---
 document.addEventListener('DOMContentLoaded', () => {
     // Core UI Initializers
@@ -1226,6 +1270,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeGuidanceGems();
     initializeAssetImporter();
     initializeTabs();
+    initializeEditToggles();
 
     // Workflow and Generation Initializers
     initializeGeneration();

--- a/style/style.css
+++ b/style/style.css
@@ -632,6 +632,86 @@ select.input-field {
     cursor: not-allowed;
 }
 
+/* --- Edit Mode Toggle Switch --- */
+.edit-toggle-container {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.edit-toggle-label {
+    font-size: 0.9rem;
+    color: var(--medium-text);
+    font-weight: 500;
+}
+
+.edit-toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 44px;
+    height: 24px;
+}
+
+.edit-toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.edit-toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #30363d;
+    transition: .4s;
+    border-radius: 24px;
+}
+
+.edit-toggle-slider:before {
+    position: absolute;
+    content: "";
+    height: 16px;
+    width: 16px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    transition: .4s;
+    border-radius: 50%;
+}
+
+input:checked + .edit-toggle-slider {
+    background-color: var(--accent-blue);
+}
+
+input:focus + .edit-toggle-slider {
+    box-shadow: 0 0 1px var(--accent-blue);
+}
+
+input:checked + .edit-toggle-slider:before {
+    transform: translateX(20px);
+}
+
+/* --- Visual Indicator for Editable Content --- */
+.editable-area.is-editable {
+    outline: 2px solid var(--accent-blue) !important;
+    box-shadow: 0 0 15px rgba(30, 64, 175, 0.3);
+    border-radius: 8px; /* Ensure the outline follows the container's shape */
+}
+
+/* Ensure the textarea for notes also gets the editable style */
+#custom-notes.is-editable {
+    outline: 2px solid var(--accent-blue);
+    box-shadow: 0 0 15px rgba(30, 64, 175, 0.3);
+}
+
+/* Make the placeholder text disappear when editable */
+.is-editable .placeholder-text {
+    display: none;
+}
+
 /* Under Construction Banner */
 .under-construction-banner {
     background: repeating-linear-gradient(


### PR DESCRIPTION
This commit introduces a read/edit toggle for the main content canvases in the Writer and Element pages.

Key changes:
- Added a toggle switch to the UI of all relevant pages.
- Implemented JavaScript to control the `contenteditable` and `disabled` states of the content areas based on the toggle's state.
- Updated the AI workflow in `writer-bundle.js` to use `innerText` to ensure user edits are captured.
- Added CSS for the toggle switch and visual indicators for editable areas.