### PR TITLE
Fix tab visibility on element pages

### DIFF
--- a/pages/faction.html
+++ b/pages/faction.html
@@ -61,7 +61,7 @@
                 </div>
 
                 <!-- Ideology & Governance Tab -->
-                <div id="ideology-tab" class="element-tab sub-tab-container">
+                <div id="ideology-tab" class="element-tab sub-tab-container hidden">
                     <div class="sub-nav glass-panel">
                         <button class="sub-nav-button active" data-sub-tab="philosophy">Beliefs & Philosophy</button>
                         <button class="sub-nav-button" data-sub-tab="power">Power & Law</button>
@@ -75,7 +75,7 @@
                             <div class="form-group"><label for="ideology-view-outsiders">View on Outsiders</label><input type="text" id="ideology-view-outsiders" class="input-field" data-field-id="view_on_outsiders" placeholder="Tolerant, xenophobic, welcoming, exploitative" autocomplete="off"></div>
                         </div>
                     </div>
-                    <div id="power-sub-tab" class="sub-tab-content">
+                    <div id="power-sub-tab" class="sub-tab-content hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group"><label for="power-government">Government Type</label><input type="text" id="power-government" class="input-field" data-field-id="government_type" placeholder="e.g., Monarchy, Council, Corporation, Democracy, Warlord" autocomplete="off"></div>
                             <div class="form-group"><label for="power-leadership">Leadership Structure</label><textarea id="power-leadership" class="input-field" data-field-id="leadership_structure" placeholder="A single leader, a ruling council, a decentralized network"></textarea></div>
@@ -87,7 +87,7 @@
                 </div>
 
                 <!-- Assets & Resources Tab -->
-                <div id="assets-tab" class="element-tab sub-tab-container">
+                <div id="assets-tab" class="element-tab sub-tab-container hidden">
                     <div class="sub-nav glass-panel">
                         <button class="sub-nav-button active" data-sub-tab="territory">Territory & Influence</button>
                         <button class="sub-nav-button" data-sub-tab="military">Military & Security</button>
@@ -100,14 +100,14 @@
                             <div class="form-group"><label for="assets-population">Population / Membership Size</label><input type="text" id="assets-population" class="input-field" data-field-id="population_size" autocomplete="off"></div>
                         </div>
                     </div>
-                    <div id="military-sub-tab" class="sub-tab-content">
+                    <div id="military-sub-tab" class="sub-tab-content hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group"><label for="assets-strength">Military Strength</label><textarea id="assets-strength" class="input-field" data-field-id="military_strength" placeholder="e.g., Elite but small, massive but poorly-equipped, unconventional"></textarea></div>
                             <div class="form-group"><label for="assets-units">Key Units / Troop Types</label><textarea id="assets-units" class="input-field" data-field-id="key_units" placeholder="Standard infantry, special forces, fleet, spies"></textarea></div>
                             <div class="form-group"><label for="assets-specialties">Technological & Tactical Specialties</label><textarea id="assets-specialties" class="input-field" data-field-id="tactical_specialties" placeholder="What are they best at? e.g., Siege warfare, espionage, cyber warfare"></textarea></div>
                         </div>
                     </div>
-                    <div id="economy-sub-tab" class="sub-tab-content">
+                    <div id="economy-sub-tab" class="sub-tab-content hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group"><label for="assets-economic-strength">Economic Strength</label><input type="text" id="assets-economic-strength" class="input-field" data-field-id="economic_strength" placeholder="Wealthy, struggling, self-sufficient" autocomplete="off"></div>
                             <div class="form-group"><label for="assets-industries">Primary Industries & Resources</label><textarea id="assets-industries" class="input-field" data-field-id="primary_industries" placeholder="What do they produce, control, or trade?"></textarea></div>
@@ -117,7 +117,7 @@
                 </div>
 
                 <!-- Culture & Society Tab -->
-                <div id="culture-tab" class="element-tab">
+                <div id="culture-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="culture-hierarchy">Social Hierarchy</label><textarea id="culture-hierarchy" class="input-field" data-field-id="social_hierarchy" placeholder="e.g., Rigid caste system, meritocracy, egalitarian"></textarea></div>
                         <div class="form-group"><label for="culture-traditions">Common Culture & Traditions</label><textarea id="culture-traditions" class="input-field" data-field-id="common_traditions" placeholder="Rituals, holidays, social norms"></textarea></div>
@@ -128,7 +128,7 @@
                 </div>
 
                 <!-- Foreign Relations Tab -->
-                <div id="relations-tab" class="element-tab">
+                <div id="relations-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="relations-allies">Allies</label><textarea id="relations-allies" class="input-field" data-field-id="allies" placeholder="List of friendly factions and the nature of the alliance"></textarea></div>
                         <div class="form-group"><label for="relations-enemies">Enemies / Rivals</label><textarea id="relations-enemies" class="input-field" data-field-id="enemies" placeholder="List of opposing factions and the source of the conflict"></textarea></div>
@@ -139,7 +139,7 @@
                 </div>
 
                 <!-- History & Origins Tab -->
-                <div id="history-tab" class="element-tab">
+                <div id="history-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="history-founding">Founding Story</label><textarea id="history-founding" class="input-field" data-field-id="founding_story" placeholder="How, when, and why was the faction created?"></textarea></div>
                         <div class="form-group"><label for="history-founders">Founders & Historical Figures</label><textarea id="history-founders" class="input-field" data-field-id="historical_figures" placeholder="Key individuals from their past"></textarea></div>
@@ -148,7 +148,7 @@
                 </div>
 
                 <!-- Notes & Concepts Tab -->
-                <div id="notes-tab" class="element-tab sub-tab-container">
+                <div id="notes-tab" class="element-tab sub-tab-container hidden">
                     <div class="sub-nav glass-panel">
                         <button class="sub-nav-button active" data-sub-tab="figures">Key Figures / NPCs</button>
                         <button class="sub-nav-button" data-sub-tab="hooks">Plot Hooks</button>
@@ -159,12 +159,12 @@
                              <textarea id="notes-figures" class="input-field" data-field-id="key_figures" placeholder="A list of important members, like the current leader, commanders, etc."></textarea>
                         </div>
                     </div>
-                    <div id="hooks-sub-tab" class="sub-tab-content">
+                    <div id="hooks-sub-tab" class="sub-tab-content hidden">
                         <div class="form-section glass-panel">
                            <textarea id="notes-hooks" class="input-field" data-field-id="plot_hooks" placeholder="Ideas for how this faction can drive the story"></textarea>
                         </div>
                     </div>
-                    <div id="gallery-sub-tab" class="sub-tab-content">
+                    <div id="gallery-sub-tab" class="sub-tab-content hidden">
                         <div class="form-section glass-panel">
                             <textarea id="notes-gallery" class="input-field" data-field-id="inspiration_gallery" placeholder="Images for mood, symbols, characters, locations"></textarea>
                         </div>

--- a/pages/scene.html
+++ b/pages/scene.html
@@ -60,7 +60,7 @@
                 </div>
 
                 <!-- Setting & Atmosphere Tab -->
-                <div id="setting-tab" class="element-tab">
+                <div id="setting-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="setting-location">Location</label><input type="text" id="setting-location" class="input-field" data-field-id="location" placeholder="Be specific: 'The dimly lit corner booth of the Red Dragon tavern,' not just 'a bar'" autocomplete="off"></div>
                         <div class="form-group"><label for="setting-time">Time of Day / Date</label><input type="text" id="setting-time" class="input-field" data-field-id="time" placeholder="" autocomplete="off"></div>
@@ -71,7 +71,7 @@
                 </div>
 
                 <!-- Characters & POV Tab -->
-                <div id="characters-tab" class="element-tab">
+                <div id="characters-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="characters-pov">Point of View (POV) Character</label><input type="text" id="characters-pov" class="input-field" data-field-id="pov_character" placeholder="From whose perspective is the scene told?" autocomplete="off"></div>
                         <div class="form-group"><label for="characters-present">Characters Present</label><textarea id="characters-present" class="input-field" data-field-id="characters_present" placeholder="List all characters physically in the scene and any others who are significantly mentioned."></textarea></div>
@@ -82,7 +82,7 @@
                 </div>
 
                 <!-- Plot & Pacing Tab -->
-                <div id="plot-tab" class="element-tab">
+                <div id="plot-tab" class="element-tab hidden">
                      <div class="form-section glass-panel">
                         <div class="form-group"><label for="plot-opening-beat">Opening Beat</label><textarea id="plot-opening-beat" class="input-field" data-field-id="opening_beat" placeholder="How does the scene begin? What is the first image, action, or line of dialogue?"></textarea></div>
                         <div class="form-group"><label for="plot-sequence">Sequence of Events</label><textarea id="plot-sequence" class="input-field" data-field-id="sequence" placeholder="A bulleted list of the major actions and turning points."></textarea></div>
@@ -96,7 +96,7 @@
                 </div>
 
                 <!-- Sensory Details & Dialogue Tab -->
-                <div id="sensory-tab" class="element-tab sub-tab-container">
+                <div id="sensory-tab" class="element-tab sub-tab-container hidden">
                     <div class="sub-nav glass-panel">
                         <button class="sub-nav-button active" data-sub-tab="sensory-details">Sensory Details</button>
                         <button class="sub-nav-button" data-sub-tab="dialogue">Dialogue</button>
@@ -110,7 +110,7 @@
                             <div class="form-group"><label for="sensory-symbolism">Dominant Imagery / Symbolism</label><textarea id="sensory-symbolism" class="input-field" data-field-id="symbolism" placeholder="Is there a recurring image or symbol used in the scene?"></textarea></div>
                         </div>
                     </div>
-                    <div id="dialogue-sub-tab" class="sub-tab-content">
+                    <div id="dialogue-sub-tab" class="sub-tab-content hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group"><label for="dialogue-key-lines">Key Lines of Dialogue</label><textarea id="dialogue-key-lines" class="input-field" data-field-id="key_lines" placeholder="What are the most impactful or informative things said?"></textarea></div>
                             <div class="form-group"><label for="dialogue-subtext">Subtext</label><textarea id="dialogue-subtext" class="input-field" data-field-id="subtext" placeholder="What is being communicated without being said directly? What are the underlying tensions, desires, or secrets?"></textarea></div>
@@ -120,7 +120,7 @@
                 </div>
 
                 <!-- Scene Checklist Tab -->
-                <div id="checklist-tab" class="element-tab">
+                <div id="checklist-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="checklist-advances-plot">Does this scene advance the plot?</label><textarea id="checklist-advances-plot" class="input-field" data-field-id="advances_plot" placeholder="Yes/No. If yes, how?"></textarea></div>
                         <div class="form-group"><label for="checklist-reveals-character">Does this scene reveal new information about a character?</label><textarea id="checklist-reveals-character" class="input-field" data-field-id="reveals_character" placeholder="Yes/No. If yes, what?"></textarea></div>

--- a/pages/setting.html
+++ b/pages/setting.html
@@ -61,7 +61,7 @@
                     </div>
 
                     <!-- Geography & Environment Tab -->
-                    <div id="geography-tab" class="element-tab">
+                    <div id="geography-tab" class="element-tab hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group"><label for="geography-cosmology">Cosmology & Astronomy</label><textarea id="geography-cosmology" class="input-field" data-field-id="cosmology" placeholder="Planet type, star system, moons, unique celestial phenomena."></textarea></div>
                             <div class="form-group"><label for="geography-climate">Climate & Weather Patterns</label><textarea id="geography-climate" class="input-field" data-field-id="climate" placeholder="e.g., Arid, tropical; predictable seasons, magical storms."></textarea></div>
@@ -73,7 +73,7 @@
                     </div>
 
                     <!-- Flora & Fauna Tab -->
-                    <div id="flora-tab" class="element-tab">
+                    <div id="flora-tab" class="element-tab hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group"><label for="flora-ecosystems">Dominant Ecosystems</label><textarea id="flora-ecosystems" class="input-field" data-field-id="ecosystems" placeholder="e.g., Bioluminescent fungus forest, sentient coral reef."></textarea></div>
                             <div class="form-group"><label for="flora-plants">Key Flora (Plants)</label><textarea id="flora-plants" class="input-field" data-field-id="plants" placeholder="Notable trees, flowers, crops. Mundane, magical, carnivorous?"></textarea></div>
@@ -83,7 +83,7 @@
                     </div>
 
                     <!-- History & Lore Tab -->
-                    <div id="history-tab" class="element-tab">
+                    <div id="history-tab" class="element-tab hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group"><label for="history-origin">Origin / Creation Myth</label><textarea id="history-origin" class="input-field" data-field-id="origin" placeholder="How did this place come to be?"></textarea></div>
                             <div class="form-group"><label for="history-timeline">Timeline of Major Eras</label><textarea id="history-timeline" class="input-field" data-field-id="timeline" placeholder="e.g., The Age of Giants, The Great Schism. List key events."></textarea></div>
@@ -94,7 +94,7 @@
                     </div>
 
                     <!-- Culture & Society Tab -->
-                    <div id="culture-tab" class="element-tab">
+                    <div id="culture-tab" class="element-tab hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group"><label for="culture-demographics">Demographics</label><textarea id="culture-demographics" class="input-field" data-field-id="demographics" placeholder="Dominant species, minority groups, population density."></textarea></div>
                             <div class="form-group"><label for="culture-government">Government & Politics</label><textarea id="culture-government" class="input-field" data-field-id="government" placeholder="e.g., Feudal monarchy, corporate council, theocratic state."></textarea></div>
@@ -108,7 +108,7 @@
                     </div>
 
                     <!-- Key Locations & Landmarks Tab -->
-                    <div id="locations-tab" class="element-tab">
+                    <div id="locations-tab" class="element-tab hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group"><label for="locations-cities">Major Cities & Settlements</label><textarea id="locations-cities" class="input-field" data-field-id="cities" placeholder="The capital, trade hubs, religious centers, remote villages."></textarea></div>
                             <div class="form-group"><label for="locations-manmade">Significant Man-Made Landmarks</label><textarea id="locations-manmade" class="input-field" data-field-id="manmade_landmarks" placeholder="e.g., The Grand Citadel, The Sunken Temple, The Sky-Spire."></textarea></div>
@@ -118,7 +118,7 @@
                     </div>
 
                     <!-- Atmosphere & Sensory Details Tab -->
-                    <div id="atmosphere-tab" class="element-tab">
+                    <div id="atmosphere-tab" class="element-tab hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group"><label for="atmosphere-sights">Dominant Sights (Color Palette)</label><textarea id="atmosphere-sights" class="input-field" data-field-id="sights" placeholder="e.g., Neon glow, sun-bleached sandstone, vibrant greens."></textarea></div>
                             <div class="form-group"><label for="atmosphere-sounds">Pervasive Sounds</label><textarea id="atmosphere-sounds" class="input-field" data-field-id="sounds" placeholder="e.g., Howling wind, hum of machinery, eerie silence."></textarea></div>

--- a/pages/species.html
+++ b/pages/species.html
@@ -60,7 +60,7 @@
                 </div>
 
                 <!-- Biology & Physiology Tab -->
-                <div id="biology-tab" class="element-tab sub-tab-container">
+                <div id="biology-tab" class="element-tab sub-tab-container hidden">
                      <div class="sub-nav glass-panel">
                         <button class="sub-nav-button active" data-sub-tab="anatomy">Anatomy & Appearance</button>
                         <button class="sub-nav-button" data-sub-tab="systems">Internal Systems & Life Cycle</button>
@@ -76,7 +76,7 @@
                             <div class="form-group"><label for="biology-head">Head & Facial Features</label><textarea id="biology-head" class="input-field" data-field-id="head" placeholder="Eyes, mouth, sensory organs"></textarea></div>
                         </div>
                     </div>
-                    <div id="systems-sub-tab" class="sub-tab-content">
+                    <div id="systems-sub-tab" class="sub-tab-content hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group"><label for="biology-diet">Diet & Metabolism</label><textarea id="biology-diet" class="input-field" data-field-id="diet" placeholder="Carnivore, herbivore, omnivore, lithovore, photosynthesizer"></textarea></div>
                             <div class="form-group"><label for="biology-senses">Senses</label><textarea id="biology-senses" class="input-field" data-field-id="senses" placeholder="Sight, hearing, smell, touch, taste, and any unique senses"></textarea></div>
@@ -89,7 +89,7 @@
                 </div>
 
                 <!-- Psychology & Cognition Tab -->
-                <div id="psychology-tab" class="element-tab">
+                <div id="psychology-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="psych-intelligence">Intelligence & Problem-Solving</label><textarea id="psych-intelligence" class="input-field" data-field-id="intelligence" placeholder="How do they think? Logical, intuitive, creative, analytical"></textarea></div>
                         <div class="form-group"><label for="psych-communication">Primary Method of Communication</label><textarea id="psych-communication" class="input-field" data-field-id="communication" placeholder="Spoken language, telepathy, chemical signals, light patterns, body language"></textarea></div>
@@ -102,7 +102,7 @@
                 </div>
 
                 <!-- Culture & Society Tab -->
-                <div id="culture-tab" class="element-tab sub-tab-container">
+                <div id="culture-tab" class="element-tab sub-tab-container hidden">
                     <div class="sub-nav glass-panel">
                         <button class="sub-nav-button active" data-sub-tab="organization">Social Organization</button>
                         <button class="sub-nav-button" data-sub-tab="traditions">Traditions & Technology</button>
@@ -116,7 +116,7 @@
                             <div class="form-group"><label for="culture-gender-roles">Gender Roles & Family Structure</label><textarea id="culture-gender-roles" class="input-field" data-field-id="gender_roles"></textarea></div>
                         </div>
                     </div>
-                    <div id="traditions-sub-tab" class="sub-tab-content">
+                    <div id="traditions-sub-tab" class="sub-tab-content hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group"><label for="culture-language">Language(s)</label><input type="text" id="culture-language" class="input-field" data-field-id="language" placeholder="Written and/or spoken" autocomplete="off"></div>
                             <div class="form-group"><label for="culture-technology">Technology Level</label><input type="text" id="culture-technology" class="input-field" data-field-id="technology" placeholder="e.g., Stone Age, Industrial, Information Age, Interstellar" autocomplete="off"></div>
@@ -129,7 +129,7 @@
                 </div>
 
                 <!-- Ecology & Habitat Tab -->
-                <div id="ecology-tab" class="element-tab">
+                <div id="ecology-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="ecology-homeworld-desc">Homeworld Description</label><textarea id="ecology-homeworld-desc" class="input-field" data-field-id="homeworld_description" placeholder="Planet type, climate, geography, flora, fauna"></textarea></div>
                         <div class="form-group"><label for="ecology-niche">Habitat/Niche</label><textarea id="ecology-niche" class="input-field" data-field-id="niche" placeholder="What role do they fill in their ecosystem?"></textarea></div>
@@ -140,7 +140,7 @@
                 </div>
 
                 <!-- Abilities & Traits Tab -->
-                <div id="abilities-tab" class="element-tab">
+                <div id="abilities-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="abilities-inherent">Inherent Abilities</label><textarea id="abilities-inherent" class="input-field" data-field-id="inherent_abilities" placeholder="Natural camouflage, flight, venom, regeneration, telekinesis, etc."></textarea></div>
                         <div class="form-group"><label for="abilities-strengths">Species-Specific Strengths</label><textarea id="abilities-strengths" class="input-field" data-field-id="strengths" placeholder="e.g., Great physical strength, high intelligence, resistance to heat"></textarea></div>
@@ -150,7 +150,7 @@
                 </div>
 
                 <!-- Notes & Concepts Tab -->
-                <div id="notes-tab" class="element-tab sub-tab-container">
+                <div id="notes-tab" class="element-tab sub-tab-container hidden">
                     <div class="sub-nav glass-panel">
                         <button class="sub-nav-button active" data-sub-tab="notes-general">General Notes</button>
                         <button class="sub-nav-button" data-sub-tab="notes-gallery">Inspiration Gallery</button>
@@ -162,7 +162,7 @@
                             </div>
                         </div>
                     </div>
-                    <div id="notes-gallery-sub-tab" class="sub-tab-content">
+                    <div id="notes-gallery-sub-tab" class="sub-tab-content hidden">
                         <div class="form-section glass-panel">
                             <div class="form-group">
                                 <label for="species-gallery">Inspiration Gallery</label>

--- a/pages/technology.html
+++ b/pages/technology.html
@@ -59,7 +59,7 @@
                 </div>
 
                 <!-- Mechanics & Principles Tab -->
-                <div id="mechanics-tab" class="element-tab">
+                <div id="mechanics-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="tech-power-source">Power Source</label><textarea id="tech-power-source" class="input-field" data-field-id="power_source" placeholder="What fuels it? (e.g., Electricity, mana, steam, chemical reaction, psionic focus, solar power, life force)"></textarea></div>
                         <div class="form-group"><label for="tech-principles">Operating Principles</label><textarea id="tech-principles" class="input-field" data-field-id="principles" placeholder="Briefly explain the scientific or magical rules that make it work."></textarea></div>
@@ -69,7 +69,7 @@
                 </div>
 
                 <!-- Origin & History Tab -->
-                <div id="history-tab" class="element-tab">
+                <div id="history-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="tech-inventor">Inventor(s) / Creator(s)</label><textarea id="tech-inventor" class="input-field" data-field-id="inventor" placeholder="Who invented or discovered it? (e.g., A lone genius, a corporate R&D department, a divine being, an ancient race)"></textarea></div>
                         <div class="form-group"><label for="tech-invention-date">Date & Place of Invention</label><textarea id="tech-invention-date" class="input-field" data-field-id="invention_date" placeholder="When and where did it first appear in the world's timeline?"></textarea></div>
@@ -79,7 +79,7 @@
                 </div>
 
                 <!-- Design & Aesthetics Tab -->
-                <div id="design-tab" class="element-tab">
+                <div id="design-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="tech-physical-desc">Physical Description</label><textarea id="tech-physical-desc" class="input-field" data-field-id="physical_desc" placeholder="Size, shape, weight, materials used."></textarea></div>
                         <div class="form-group"><label for="tech-sensory-details">Sensory Details</label><textarea id="tech-sensory-details" class="input-field" data-field-id="sensory_details" placeholder="What does it look, sound, smell, and feel like when in use?"></textarea></div>
@@ -88,7 +88,7 @@
                 </div>
 
                 <!-- Production & Distribution Tab -->
-                <div id="production-tab" class="element-tab">
+                <div id="production-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="tech-resources">Required Resources</label><textarea id="tech-resources" class="input-field" data-field-id="resources" placeholder="What rare or common materials are needed to build it?"></textarea></div>
                         <div class="form-group"><label for="tech-manufacturing">Manufacturing Process</label><textarea id="tech-manufacturing" class="input-field" data-field-id="manufacturing" placeholder="How is it made? (e.g., Mass-produced, handcrafted, grown in a bio-vat, summoned)"></textarea></div>
@@ -98,7 +98,7 @@
                 </div>
 
                 <!-- Societal & Cultural Impact Tab -->
-                <div id="impact-tab" class="element-tab">
+                <div id="impact-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="tech-economic-impact">Economic Impact</label><textarea id="tech-economic-impact" class="input-field" data-field-id="economic_impact" placeholder="Did it create new industries or make old ones obsolete?"></textarea></div>
                         <div class="form-group"><label for="tech-social-impact">Social Impact</label><textarea id="tech-social-impact" class="input-field" data-field-id="social_impact" placeholder="How did it change daily life, social structures, or class divisions?"></textarea></div>
@@ -108,7 +108,7 @@
                 </div>
 
                 <!-- Usage & Narrative Role Tab -->
-                <div id="narrative-tab" class="element-tab">
+                <div id="narrative-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="tech-primary-users">Primary User(s)</label><textarea id="tech-primary-users" class="input-field" data-field-id="primary_users" placeholder="Who typically uses this technology? (e.g., A specific social class, a military unit, a magical order, the general public)"></textarea></div>
                         <div class="form-group"><label for="tech-strengths">Strengths & Advantages</label><textarea id="tech-strengths" class="input-field" data-field-id="strengths" placeholder="What does it allow a user to do better than anything else?"></textarea></div>

--- a/pages/world.html
+++ b/pages/world.html
@@ -62,7 +62,7 @@
                 </div>
 
                 <!-- The Physical World Tab -->
-                <div id="physical-tab" class="element-tab">
+                <div id="physical-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="physical-stars">Star System</label><textarea id="physical-stars" class="input-field" data-field-id="star_system" placeholder="Star type(s), number of planets, unique astronomical features."></textarea></div>
                         <div class="form-group"><label for="physical-stats">Planetary Statistics</label><textarea id="physical-stats" class="input-field" data-field-id="planetary_stats" placeholder="Size, gravity, axial tilt, length of day and year."></textarea></div>
@@ -73,7 +73,7 @@
                 </div>
 
                 <!-- Global History & Timeline Tab -->
-                <div id="history-tab" class="element-tab">
+                <div id="history-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="history-creation">Creation Myth / Origin Story</label><textarea id="history-creation" class="input-field" data-field-id="creation_myth" placeholder="The commonly accepted (or true) story of the world's beginning."></textarea></div>
                         <div class="form-group"><label for="history-ages">Timeline of Major Ages</label><textarea id="history-ages" class="input-field" data-field-id="major_ages" placeholder="Define the great epochs of your world's history (e.g., The Primordial Age, The Age of Gods)."></textarea></div>
@@ -84,7 +84,7 @@
                 </div>
 
                 <!-- Life & Inhabitants Tab -->
-                <div id="inhabitants-tab" class="element-tab">
+                <div id="inhabitants-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="life-origin">Origin of Life</label><textarea id="life-origin" class="input-field" data-field-id="life_origin" placeholder="e.g., Divine creation, evolution, alien seeding."></textarea></div>
                         <div class="form-group"><label for="life-species">Major Sentient Species</label><textarea id="life-species" class="input-field" data-field-id="sentient_species" placeholder="List the primary species, their homelands, and their general relationships."></textarea></div>
@@ -95,7 +95,7 @@
                 </div>
 
                 <!-- World Systems Tab -->
-                <div id="systems-tab" class="element-tab">
+                <div id="systems-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="systems-tech">Technology Level</label><textarea id="systems-tech" class="input-field" data-field-id="tech_level" placeholder="What is the baseline tech? Are there pockets of higher or lower technology?"></textarea></div>
                         <div class="form-group"><label for="systems-economy">Global Economy</label><textarea id="systems-economy" class="input-field" data-field-id="economy" placeholder="Major trade routes, common currencies, and influential economic powers."></textarea></div>
@@ -106,7 +106,7 @@
                 </div>
 
                 <!-- Metaphysics & The Divine Tab -->
-                <div id="metaphysics-tab" class="element-tab">
+                <div id="metaphysics-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="meta-gods">Gods & Pantheons</label><textarea id="meta-gods" class="input-field" data-field-id="gods" placeholder="Major deities, their domains, relationships, and level of interaction with the mortal world."></textarea></div>
                         <div class="form-group"><label for="meta-afterlife">The Afterlife</label><textarea id="meta-afterlife" class="input-field" data-field-id="afterlife" placeholder="What do people believe happens after death? Is it a known fact?"></textarea></div>
@@ -116,7 +116,7 @@
                 </div>
 
                 <!-- World Themes & Tone Tab -->
-                <div id="themes-tab" class="element-tab">
+                <div id="themes-tab" class="element-tab hidden">
                     <div class="form-section glass-panel">
                         <div class="form-group"><label for="themes-central">Central Themes</label><textarea id="themes-central" class="input-field" data-field-id="central_themes" placeholder="e.g., Order vs. Chaos, Progress vs. Tradition, Hope vs. Despair."></textarea></div>
                         <div class="form-group"><label for="themes-tone">Overall Tone</label><textarea id="themes-tone" class="input-field" data-field-id="tone" placeholder="e.g., Grimdark, Noblebright, Satirical, Adventurous, Mysterious, Horror."></textarea></div>


### PR DESCRIPTION
The `species`, `faction`, `scene`, `setting`, `world`, and `technology` pages had a bug where all tabs were visible at once, instead of only the active tab being visible.

This was caused by the inactive tab content `div`s missing the `hidden` class.

This commit adds the `hidden` class to all inactive tab and sub-tab containers on the affected pages, matching the correct implementation in `persona.html`.