### PR TITLE
feat: Remove Imaging Studio feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,10 +23,6 @@
         <nav class="main-nav">
             <a href="pages/elements.html">Elements</a>
             <a href="pages/writer.html">Writer</a>
-            <a href="pages/imaging.html">Imaging</a>
-            <!-- <a href="pages/audio.html">Audio</a> -->
-            <!-- <a href="pages/3d.html">3D</a> -->
-            <!-- <a href="pages/video.html">Video</a> -->
         </nav>
     </header>
 
@@ -47,12 +43,6 @@
                 <h3 class="card-title">Story Weaver</h3>
                 <p class="card-description">
                     A comprehensive four-stage environment to guide your narrative from brainstorm to final draft.
-                </p>
-            </a>
-            <a href="pages/imaging.html" class="hub-card glass-panel">
-                <h3 class="card-title">Imaging Studio</h3>
-                <p class="card-description">
-                    Bring your world to life. Generate concept art, character portraits, and landscapes based on your created Elements.
                 </p>
             </a>
             <!-- <a href="pages/3d.html" class="hub-card glass-panel">

--- a/pages/elements.html
+++ b/pages/elements.html
@@ -23,9 +23,6 @@
         <nav class="main-nav">
             <a href="elements.html" class="active">Elements</a>
             <a href="writer.html">Writer</a>
-            <!-- <a href="audio.html">Audio</a> -->
-            <!-- <a href="3d.html">3D</a> -->
-            <!-- <a href="video.html">Video</a> -->
         </nav>
     </header>
 

--- a/pages/faction.html
+++ b/pages/faction.html
@@ -25,7 +25,6 @@
         <nav class="main-nav">
             <a href="elements.html" class="active">Elements</a>
             <a href="writer.html">Writer</a>
-            <a href="imaging.html">Imaging</a>
         </nav>
     </header>
 

--- a/pages/persona.html
+++ b/pages/persona.html
@@ -25,7 +25,6 @@
         <nav class="main-nav">
             <a href="elements.html" class="active">Elements</a>
             <a href="writer.html">Writer</a>
-            <a href="imaging.html">Imaging</a>
         </nav>
     </header>
 

--- a/pages/philosophy.html
+++ b/pages/philosophy.html
@@ -25,7 +25,6 @@
         <nav class="main-nav">
             <a href="elements.html" class="active">Elements</a>
             <a href="writer.html">Writer</a>
-            <a href="imaging.html">Imaging</a>
         </nav>
     </header>
 

--- a/pages/scene.html
+++ b/pages/scene.html
@@ -25,7 +25,6 @@
         <nav class="main-nav">
             <a href="elements.html" class="active">Elements</a>
             <a href="writer.html">Writer</a>
-            <a href="imaging.html">Imaging</a>
         </nav>
     </header>
 

--- a/pages/setting.html
+++ b/pages/setting.html
@@ -25,7 +25,6 @@
         <nav class="main-nav">
             <a href="elements.html" class="active">Elements</a>
             <a href="writer.html">Writer</a>
-            <a href="imaging.html">Imaging</a>
         </nav>
     </header>
 

--- a/pages/species.html
+++ b/pages/species.html
@@ -25,7 +25,6 @@
         <nav class="main-nav">
             <a href="elements.html" class="active">Elements</a>
             <a href="writer.html">Writer</a>
-            <a href="imaging.html">Imaging</a>
         </nav>
     </header>
 

--- a/pages/technology.html
+++ b/pages/technology.html
@@ -25,7 +25,6 @@
         <nav class="main-nav">
             <a href="elements.html" class="active">Elements</a>
             <a href="writer.html">Writer</a>
-            <a href="imaging.html">Imaging</a>
         </nav>
     </header>
 

--- a/pages/universe.html
+++ b/pages/universe.html
@@ -25,7 +25,6 @@
         <nav class="main-nav">
             <a href="elements.html" class="active">Elements</a>
             <a href="writer.html">Writer</a>
-            <a href="imaging.html">Imaging</a>
         </nav>
     </header>
 

--- a/pages/world.html
+++ b/pages/world.html
@@ -25,7 +25,6 @@
         <nav class="main-nav">
             <a href="elements.html" class="active">Elements</a>
             <a href="writer.html">Writer</a>
-            <a href="imaging.html">Imaging</a>
         </nav>
     </header>
 

--- a/pages/writer.html
+++ b/pages/writer.html
@@ -24,10 +24,6 @@
         <nav class="main-nav">
             <a href="elements.html">Elements</a>
             <a href="writer.html" class="active">Writer</a>
-            <a href="imaging.html">Imaging</a>
-            <!-- <a href="audio.html">Audio</a> -->
-            <!-- <a href="3d.html">3D</a> -->
-            <!-- <a href="video.html">Video</a> -->
         </nav>
     </header>
 


### PR DESCRIPTION
This commit removes all user-facing references to the Imaging Studio feature.

- Removes the "Imaging" link from the main navigation header on the Creative Hub, Writer, and all Element pages.
- Removes the "Imaging Studio" card from the Creative Hub grid.
- Cleans up commented-out, unused navigation links in the headers for consistency.