### PR TITLE
feat(scenario-guide): Add Asset Hub, Guidance Gems, and Editable Canvas

### DIFF
--- a/pages/scenario-guide.html
+++ b/pages/scenario-guide.html
@@ -61,8 +61,7 @@
             <div id="toc-list" class="panel-content space-y-1">
                 <!-- Table of Contents items will be dynamically inserted here -->
             </div>
-            <div class="panel-footer flex gap-2">
-                <button id="gmViewButton" class="w-full px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-md text-white">GM View</button>
+            <div class="panel-footer">
                 <button id="addComponentButton" class="w-full px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded-md text-white">Add Component</button>
             </div>
         </aside>
@@ -70,11 +69,16 @@
             <!-- Center Panel: Main Content -->
             <div class="main-column">
                 <main id="main-panel" class="panel">
-                    <div id="main-panel-header" class="panel-header flex items-center gap-4">
-                        <button id="backButton" data-action="back" title="Back to Contents" class="p-2 rounded-md hover:bg-gray-700 hidden lg:hidden">
-                            <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" /></svg>
+                    <div id="main-panel-header" class="panel-header flex items-center justify-between gap-4">
+                        <div class="flex items-center gap-4">
+                            <button id="backButton" data-action="back" title="Back to Contents" class="p-2 rounded-md hover:bg-gray-700 hidden lg:hidden">
+                                <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" /></svg>
+                            </button>
+                            <h1 id="project-title-display" class="text-2xl truncate">New Project</h1>
+                        </div>
+                        <button id="side-column-toggle" class="side-column-toggle" title="Toggle Sidebar">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
                         </button>
-                        <h1 id="project-title-display" class="text-2xl truncate">New Project</h1>
                     </div>
                     <div id="main-scroll-area" class="panel-content">
                         <div id="projectHeader" class="mb-12"></div>
@@ -85,21 +89,32 @@
                 </main>
             </div>
 
-            <!-- Right Panel: Asset Hub & Quick Reference -->
-            <aside class="side-column">
-                <div class="asset-hub-panel glass-panel writer-mode-only">
-                    <h3 class="side-panel-title">Asset Hub</h3>
-                    <p class="asset-hub-subtitle">Import AIME elements and files for contextual reference.</p>
-                    <button id="import-asset-btn" class="import-btn">Import Asset</button>
-                    <div id="asset-list" class="asset-list"></div>
-                </div>
-                <div id="quick-ref-panel" class="panel gm-mode-only">
-                    <div class="panel-header">
-                        <h2 class="text-xl">Quick Reference</h2>
+            <!-- Right Panel: Asset Hub & Guidance Gems -->
+            <aside class="side-column is-open">
+                <div class="side-panel-content">
+                    <div class="asset-hub-panel glass-panel">
+                        <h3 class="side-panel-title">Asset Hub</h3>
+                        <p class="asset-hub-subtitle">Import AIME elements and files for contextual reference.</p>
+                        <button id="import-asset-btn" class="import-btn">Import Asset</button>
+                        <div id="asset-list" class="asset-list"></div>
                     </div>
-                    <div id="quick-ref-list" class="panel-content"></div>
+                    <div id="guidance-gems-container" class="glass-panel">
+                        <h3 class="side-panel-title">Guidance Gems</h3>
+                        <p class="asset-hub-subtitle">Use creative prompts and structural ideas to flesh out your scenario.</p>
+                        <button id="guidance-gems-btn" class="import-btn">Explore Gems</button>
+                    </div>
                 </div>
             </aside>
+        </div>
+    </div>
+
+    <!-- Guidance Gems Modal -->
+    <div id="guidance-gems-modal" class="modal-overlay hidden">
+        <div class="modal-content">
+            <h2 class="modal-title">Guidance Gems</h2>
+            <div id="gem-categories" class="gem-categories"></div>
+            <div id="gem-content-container" class="gem-content-container"></div>
+            <button id="close-guidance-gems-modal" class="modal-close-btn">&times;</button>
         </div>
     </div>
     


### PR DESCRIPTION
This commit brings the Scenario Guide module to feature parity with the other AIME modules by implementing three key features:

1.  **Asset Hub:** Integrates the Asset Hub into a right-hand sidebar, allowing users to import AIME elements and other files for contextual reference. The `craftSuperPrompt` function has been updated to include data from these assets in AI prompts.

2.  **Guidance Gems:** Adds a new Guidance Gems system with scenario-specific creative prompts. The UI and logic for the gem selection modal are implemented, allowing users to insert content directly into the active editor.

3.  **Always-Editable Canvas:** Removes the previous "GM View" and "Writer Mode" toggles, making all component fields permanently editable for a more streamlined user experience. All related UI and JavaScript logic have been refactored.