### PR TITLE
feat: Update header navigation and cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,9 +21,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="pages/elements.html">Elements</a>
-            <a href="pages/writer.html">Writer</a>
-            <a href="pages/sg-hub.html">Scenario Guide</a>
+            <a href="pages/elements.html">Writer Hub</a>
+            <a href="pages/sg-hub.html">Scenario</a>
         </nav>
     </header>
 
@@ -35,13 +34,13 @@
 
         <div class="hub-grid">
             <a href="pages/elements.html" class="hub-card glass-panel">
-                <h3 class="card-title">Writer</h3>
+                <h3 class="card-title">Writer Hub</h3>
                 <p class="card-description">
                     Forge the building blocks of your universe. Define the characters, worlds, and rules that make your story unique.
                 </p>
             </a>
             <a href="pages/sg-hub.html" class="hub-card glass-panel">
-                <h3 class="card-title">Scenario Guide</h3>
+                <h3 class="card-title">Scenario</h3>
                 <p class="card-description">
                     A dedicated environment for designing RPG modules and scenarios, from story arcs to individual encounters.
                 </p>

--- a/pages/3d.html
+++ b/pages/3d.html
@@ -24,13 +24,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
-            <a href="imaging.html">Imaging</a>
-            <!-- <a href="audio.html">Audio</a> -->
-            <a href="3d.html" class="active">3D</a>
-            <!-- <a href="video.html">Video</a> -->
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 

--- a/pages/audio.html
+++ b/pages/audio.html
@@ -22,13 +22,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
-            <a href="imaging.html">Imaging</a>
-            <a href="audio.html" class="active">Audio</a>
-            <!-- <a href="3d.html">3D</a> -->
-            <!-- <a href="video.html">Video</a> -->
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 

--- a/pages/elements.html
+++ b/pages/elements.html
@@ -21,9 +21,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html" class="active">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
+            <a href="elements.html" class="active">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 

--- a/pages/faction.html
+++ b/pages/faction.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html" class="active">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
+            <a href="elements.html" class="active">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 

--- a/pages/persona.html
+++ b/pages/persona.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html" class="active">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
+            <a href="elements.html" class="active">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 

--- a/pages/philosophy.html
+++ b/pages/philosophy.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html" class="active">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
+            <a href="elements.html" class="active">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 

--- a/pages/scene.html
+++ b/pages/scene.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html" class="active">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
+            <a href="elements.html" class="active">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 

--- a/pages/setting.html
+++ b/pages/setting.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html" class="active">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
+            <a href="elements.html" class="active">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 

--- a/pages/sg-adventure.html
+++ b/pages/sg-adventure.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html" class="active">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html" class="active">Scenario</a>
         </nav>
     </header>
 

--- a/pages/sg-clue.html
+++ b/pages/sg-clue.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html" class="active">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html" class="active">Scenario</a>
         </nav>
     </header>
 

--- a/pages/sg-encounter.html
+++ b/pages/sg-encounter.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html" class="active">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html" class="active">Scenario</a>
         </nav>
     </header>
 

--- a/pages/sg-group.html
+++ b/pages/sg-group.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html" class="active">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html" class="active">Scenario</a>
         </nav>
     </header>
 

--- a/pages/sg-handout.html
+++ b/pages/sg-handout.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html" class="active">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html" class="active">Scenario</a>
         </nav>
     </header>
 

--- a/pages/sg-hub.html
+++ b/pages/sg-hub.html
@@ -21,9 +21,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html" class="active">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html" class="active">Scenario</a>
         </nav>
     </header>
 

--- a/pages/sg-item.html
+++ b/pages/sg-item.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html" class="active">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html" class="active">Scenario</a>
         </nav>
     </header>
 

--- a/pages/sg-location.html
+++ b/pages/sg-location.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html" class="active">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html" class="active">Scenario</a>
         </nav>
     </header>
 

--- a/pages/sg-map.html
+++ b/pages/sg-map.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html" class="active">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html" class="active">Scenario</a>
         </nav>
     </header>
 

--- a/pages/sg-module.html
+++ b/pages/sg-module.html
@@ -22,9 +22,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html" class="active">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html" class="active">Scenario</a>
         </nav>
     </header>
 

--- a/pages/sg-npc.html
+++ b/pages/sg-npc.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html" class="active">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html" class="active">Scenario</a>
         </nav>
     </header>
 

--- a/pages/sg-storyarc.html
+++ b/pages/sg-storyarc.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html" class="active">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html" class="active">Scenario</a>
         </nav>
     </header>
 

--- a/pages/species.html
+++ b/pages/species.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html" class="active">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
+            <a href="elements.html" class="active">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 

--- a/pages/technology.html
+++ b/pages/technology.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html" class="active">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
+            <a href="elements.html" class="active">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 

--- a/pages/universe.html
+++ b/pages/universe.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html" class="active">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
+            <a href="elements.html" class="active">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 

--- a/pages/video.html
+++ b/pages/video.html
@@ -22,13 +22,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
-            <a href="imaging.html">Imaging</a>
-            <!-- <a href="audio.html">Audio</a> -->
-            <!-- <a href="3d.html">3D</a> -->
-            <a href="video.html" class="active">Video</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
     <main class="container">

--- a/pages/world.html
+++ b/pages/world.html
@@ -23,9 +23,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html" class="active">Elements</a>
-            <a href="writer.html">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
+            <a href="elements.html" class="active">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 

--- a/pages/writer.html
+++ b/pages/writer.html
@@ -22,9 +22,8 @@
             </button>
         </div>
         <nav class="main-nav">
-            <a href="elements.html">Elements</a>
-            <a href="writer.html" class="active">Writer</a>
-            <a href="sg-hub.html">Scenario Guide</a>
+            <a href="elements.html">Writer Hub</a>
+            <a href="sg-hub.html">Scenario</a>
         </nav>
     </header>
 


### PR DESCRIPTION
Removes the "Elements" link from the header.
Changes the "Writer" link to "Writer Hub" and points it to `pages/elements.html`. Changes the "Scenario Guide" link and card to "Scenario". Updates the "Writer" card to "Writer Hub" on the index page.