### PR TITLE
feat(hubs): Center cards and highlight main cards

### DIFF
--- a/pages/sg-hub.html
+++ b/pages/sg-hub.html
@@ -32,6 +32,10 @@
             <p class="hub-subtitle">Forge the building blocks of your RPG Scenarios. Each Element is a reusable Asset.</p>
         </div>
         <div class="hub-grid">
+            <a href="sg-module.html" class="hub-card glass-panel hub-card-double">
+                <h3 class="card-title animated-gradient">MODULE</h3>
+                <p class="card-description">A comprehensive environment to guide your scenario from concept to final draft.</p>
+            </a>
             <a href="sg-storyarc.html" class="hub-card glass-panel"><h3 class="card-title">Story Arc</h3><p class="card-description">Define the main plot of your scenario, from inciting incident to resolution.</p></a>
             <a href="sg-adventure.html" class="hub-card glass-panel"><h3 class="card-title">Adventure</h3><p class="card-description">Create a self-contained adventure with hooks, goals, and stakes.</p></a>
             <a href="sg-npc.html" class="hub-card glass-panel"><h3 class="card-title">NPC</h3><p class="card-description">Design non-player characters with roles, motivations, and secrets.</p></a>
@@ -42,10 +46,6 @@
             <a href="sg-clue.html" class="hub-card glass-panel"><h3 class="card-title">Clue</h3><p class="card-description">Detail clues with the information they provide and where they can be found.</p></a>
             <a href="sg-map.html" class="hub-card glass-panel"><h3 class="card-title">Map</h3><p class="card-description">Create maps with pins to link to other components.</p></a>
             <a href="sg-handout.html" class="hub-card glass-panel"><h3 class="card-title">Handout</h3><p class="card-description">Design handouts for players with text and images.</p></a>
-            <a href="sg-module.html" class="hub-card glass-panel hub-card-double">
-                <h3 class="card-title">MODULE</h3>
-                <p class="card-description">A comprehensive environment to guide your scenario from concept to final draft.</p>
-            </a>
         </div>
     </main>
 

--- a/pages/writer.html
+++ b/pages/writer.html
@@ -33,6 +33,10 @@
             <p class="hub-subtitle">Forge the building blocks of your universe. Each Element is a reusable Asset.</p>
         </div>
         <div class="hub-grid">
+            <a href="compose.html" class="hub-card glass-panel hub-card-double">
+                <h3 class="card-title animated-gradient">COMPOSE</h3>
+                <p class="card-description">A comprehensive four-stage environment to guide your narrative from brainstorm to final draft.</p>
+            </a>
             <a href="persona.html" class="hub-card glass-panel"><h3 class="card-title">Persona Maker</h3><p class="card-description">Craft detailed characters with unique personalities, backstories, and motivations.</p></a>
             <a href="species.html" class="hub-card glass-panel"><h3 class="card-title">Species Creator</h3><p class="card-description">Design the biology, culture, and abilities of the various species that inhabit your world.</p></a>
             <a href="faction.html" class="hub-card glass-panel"><h3 class="card-title">Faction Shaper</h3><p class="card-description">Define the organizations that drive conflict and cooperation in your world.</p></a>
@@ -42,10 +46,6 @@
             <a href="technology.html" class="hub-card glass-panel"><h3 class="card-title">Technology Forge</h3><p class="card-description">Create specific technologies, from magical artifacts to advanced AI, and define their impact.</p></a>
             <a href="philosophy.html" class="hub-card glass-panel"><h3 class="card-title">Philosophy Scribe</h3><p class="card-description">Define the religions, belief systems, and societal creeds that shape your cultures.</p></a>
             <a href="universe.html" class="hub-card glass-panel"><h3 class="card-title">Universe Crucible</h3><p class="card-description">Establish the high-level framework: genres, themes, and the fundamental laws of your world.</p></a>
-            <a href="compose.html" class="hub-card glass-panel hub-card-double">
-                <h3 class="card-title">COMPOSE</h3>
-                <p class="card-description">A comprehensive four-stage environment to guide your narrative from brainstorm to final draft.</p>
-            </a>
         </div>
     </main>
 

--- a/style/style.css
+++ b/style/style.css
@@ -171,7 +171,8 @@ body {
 .hub-grid {
     display: grid;
     gap: 1.5rem;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+    grid-template-columns: repeat(auto-fill, 350px);
+    justify-content: center;
 }
 
 .hub-card {
@@ -190,6 +191,10 @@ body {
     border-color: rgba(76, 29, 149, 0.7);
 }
 
+.hub-card-double {
+    grid-column: span 2;
+}
+
 .card-title {
     font-size: 1.5rem;
     font-weight: 600;
@@ -197,6 +202,11 @@ body {
     margin-bottom: 0.75rem;
     border-left: 3px solid var(--accent-purple);
     padding-left: 0.75rem;
+}
+
+.card-title.animated-gradient {
+    border-left: none;
+    padding-left: 0;
 }
 
 .card-description {


### PR DESCRIPTION
- Centers the card grids on the Creative, Writer, and Scenario hubs.
- Moves the 'Compose' card to the top of the Writer Hub and makes it double-width.
- Moves the 'Module' card to the top of the Scenario Hub and makes it double-width.
- Applies a purple-to-blue animated text gradient to the 'Compose' and 'Module' card titles for emphasis.