### PR TITLE
fix(css): Correct width of custom input in guidance modal

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -1712,6 +1712,7 @@ input:checked + .edit-toggle-slider:before {
 
 .gem-modal-custom-input-area .input-field {
     flex-grow: 1;
+    width: auto; /* Override default width to allow flexbox to control it */
 }
 
 .gem-modal-custom-input-area .action-btn {


### PR DESCRIPTION
The custom input field in the guidance selection modal was not expanding to fill the available space. This was caused by a conflicting `width: 100%` rule on the `.input-field` class, which prevented the `flex-grow: 1` property from working as intended.

This commit adds a more specific CSS rule to set `width: auto` on the input field within the modal's custom input container. This override allows the flexbox layout to correctly manage the input's width, making it fully visible and usable.